### PR TITLE
Chore/parse benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,20 @@ pnpm typecheck       tsc --noEmit
 pnpm test            unit tests, offline against recorded fixtures
 pnpm test:coverage   unit tests with coverage thresholds
 pnpm test:e2e        live contract tests against play.google.com
+pnpm bench           parser benchmarks over recorded fixtures
 pnpm build           emit dist/ with esm, cjs, and d.ts
 pnpm fixtures:update refresh recorded fixtures from live Google Play
 ```
 
 Before opening a pull request, make sure `pnpm lint`, `pnpm typecheck`, `pnpm test:coverage` and `pnpm build` all pass.
+
+## Benchmarks
+
+`pnpm bench` runs the Vitest benchmark suite in `bench/` over the recorded app fixtures: script data parsing (`bench/scriptData.bench.ts`) and the full offline `app()` pipeline plus spec extraction (`bench/app.bench.ts`). A single file or name filter works as `pnpm bench scriptData` or `pnpm bench -t referenced`.
+
+Benchmarks never run in CI: shared runners have noisy neighbors and frequency scaling, so any hz threshold there would flake. For a pull request that touches `src/core/scriptData.ts`, `src/core/spec.ts`, `src/core/path.ts`, or `src/features/app/`, run `pnpm bench` locally on `main`, run it again on your branch, and paste both tables into the PR description.
+
+`bench/scriptData.bench.ts` mirrors the three block regexes from `src/core/scriptData.ts` (they are module-private there). If `scriptData.ts` ever changes them, update the mirrors in the bench file to match.
 
 ## Conventions
 

--- a/bench/app.bench.ts
+++ b/bench/app.bench.ts
@@ -1,0 +1,37 @@
+import { bench, describe } from 'vitest';
+import { parseScriptData } from '../src/core/scriptData.js';
+import { extract } from '../src/core/spec.js';
+import { createApp } from '../src/features/app/app.js';
+import { appSpecs } from '../src/features/app/specs.js';
+import { APP_FIXTURES, loadAppFixture } from './fixtures.js';
+import type { AppFixtureName } from './fixtures.js';
+
+const offlineApp = (html: string) => createApp(() => ({ request: () => Promise.resolve(html) }));
+
+const sink = { total: 0 };
+
+for (const name of Object.keys(APP_FIXTURES) as AppFixtureName[]) {
+  const html = loadAppFixture(name);
+  const appId = APP_FIXTURES[name];
+  const app = offlineApp(html);
+  const data = parseScriptData(html);
+
+  describe(name, () => {
+    bench(
+      'app() offline',
+      async () => {
+        const result = await app({ appId });
+        sink.total += result.title.length;
+      },
+      { time: 1000 },
+    );
+
+    bench(
+      'extract appSpecs',
+      () => {
+        sink.total += Object.keys(extract(data, appSpecs, 'app')).length;
+      },
+      { time: 1000 },
+    );
+  });
+}

--- a/bench/fixtures.ts
+++ b/bench/fixtures.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+
+export const APP_FIXTURES = {
+  'translate.html': 'com.google.android.apps.translate',
+  'minecraft.html': 'com.mojang.minecraftpe',
+  'whereami.html': 'com.adex77.WhereAmI',
+} as const;
+
+export type AppFixtureName = keyof typeof APP_FIXTURES;
+
+export function loadAppFixture(name: AppFixtureName): string {
+  return readFileSync(new URL(`../test/fixtures/app/${name}`, import.meta.url), 'utf8');
+}

--- a/bench/scriptData.bench.ts
+++ b/bench/scriptData.bench.ts
@@ -1,0 +1,113 @@
+import { bench, describe } from 'vitest';
+import { parseScriptData, resolveDsKey } from '../src/core/scriptData.js';
+import type { ScriptData } from '../src/core/scriptData.js';
+import type { SpecMap } from '../src/core/spec.js';
+import { appSpecs } from '../src/features/app/specs.js';
+import { APP_FIXTURES, loadAppFixture } from './fixtures.js';
+import type { AppFixtureName } from './fixtures.js';
+
+const SCRIPT_BLOCK_REGEX = />AF_initDataCallback[\s\S]*?<\/script/g;
+const BLOCK_KEY_REGEX = /(ds:.*?)'/;
+const BLOCK_PAYLOAD_REGEX = /data:([\s\S]*?), sideChannel: {}}\);<\//;
+
+const specs: SpecMap = appSpecs;
+
+function referencedDsKeys(data: ScriptData): Set<string> {
+  const keys = new Set<string>();
+  for (const spec of Object.values(specs)) {
+    for (const path of spec.paths) {
+      const head = path[0];
+      if (typeof head === 'string' && head.startsWith('ds:')) {
+        keys.add(head);
+      }
+    }
+    if (spec.serviceRequestId !== undefined) {
+      const resolved = resolveDsKey(data, spec.serviceRequestId);
+      if (resolved !== undefined) {
+        keys.add(resolved);
+      }
+    }
+  }
+  return keys;
+}
+
+function parseBlocksOnly(html: string): Record<string, unknown> {
+  const blocks: Record<string, unknown> = {};
+  const matches = html.match(SCRIPT_BLOCK_REGEX);
+  if (matches === null) {
+    return blocks;
+  }
+  for (const block of matches) {
+    const key = BLOCK_KEY_REGEX.exec(block)?.[1];
+    const payload = BLOCK_PAYLOAD_REGEX.exec(block)?.[1];
+    if (key === undefined || payload === undefined) {
+      continue;
+    }
+    try {
+      blocks[key] = JSON.parse(payload);
+    } catch {
+      continue;
+    }
+  }
+  return blocks;
+}
+
+function parseReferencedBlocks(
+  html: string,
+  referenced: ReadonlySet<string>,
+): Record<string, unknown> {
+  const blocks: Record<string, unknown> = {};
+  const matches = html.match(SCRIPT_BLOCK_REGEX);
+  if (matches === null) {
+    return blocks;
+  }
+  for (const block of matches) {
+    const key = BLOCK_KEY_REGEX.exec(block)?.[1];
+    if (key === undefined || !referenced.has(key)) {
+      continue;
+    }
+    const payload = BLOCK_PAYLOAD_REGEX.exec(block)?.[1];
+    if (payload === undefined) {
+      continue;
+    }
+    try {
+      blocks[key] = JSON.parse(payload);
+    } catch {
+      continue;
+    }
+  }
+  return blocks;
+}
+
+const sink = { total: 0 };
+
+for (const name of Object.keys(APP_FIXTURES) as AppFixtureName[]) {
+  const html = loadAppFixture(name);
+  const referenced = referencedDsKeys(parseScriptData(html));
+
+  describe(name, () => {
+    bench(
+      'parseScriptData',
+      () => {
+        sink.total += Object.keys(parseScriptData(html).blocks).length;
+      },
+      { time: 1000 },
+    );
+
+    bench(
+      'parse blocks only',
+      () => {
+        sink.total += Object.keys(parseBlocksOnly(html)).length;
+      },
+      { time: 1000 },
+    );
+
+    bench(
+      'parse referenced blocks only',
+      () => {
+        sink.total += Object.keys(parseReferencedBlocks(html, referenced)).length;
+      },
+      { time: 1000 },
+    );
+  });
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
+    "bench": "vitest bench --run --project unit",
     "test": "vitest run --project unit",
     "test:watch": "vitest --project unit",
     "test:coverage": "vitest run --project unit --coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,14 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["src", "e2e", "test", "scripts", "examples", "vitest.config.ts", "tsdown.config.ts"]
+  "include": [
+    "src",
+    "e2e",
+    "test",
+    "scripts",
+    "examples",
+    "bench",
+    "vitest.config.ts",
+    "tsdown.config.ts"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
           name: 'unit',
           include: ['src/**/*.test.ts', 'test/**/*.test.ts'],
           environment: 'node',
+          benchmark: { include: ['bench/**/*.bench.ts'] },
         },
       },
       {
@@ -19,6 +20,7 @@ export default defineConfig({
           hookTimeout: 30000,
           retry: 2,
           fileParallelism: false,
+          benchmark: { include: [] },
         },
       },
     ],


### PR DESCRIPTION
bench/scriptData.bench.ts
  translate.html                       hz      mean     rme
   · parseScriptData               2,123.71  0.4709ms  ±0.36%
   · parse blocks only             3,062.79  0.3265ms  ±0.42%
   · parse referenced blocks only  7,378.82  0.1355ms  ±0.75%
  minecraft.html
   · parseScriptData               2,107.88  0.4744ms  ±1.16%
   · parse blocks only             2,773.92  0.3605ms  ±1.51%
   · parse referenced blocks only  3,147.84  0.3177ms  ±10.11%
  whereami.html
   · parseScriptData               1,615.08  0.6192ms  ±2.89%
   · parse blocks only             2,648.50  0.3776ms  ±2.45%
   · parse referenced blocks only  6,604.09  0.1514ms  ±1.81%

bench/app.bench.ts
  translate.html
   · app() offline                   783.48  1.2764ms  ±5.55%
   · extract appSpecs              4,804.28  0.2081ms  ±1.50%
  minecraft.html
   · app() offline                 1,222.89  0.8177ms  ±1.95%
   · extract appSpecs              3,950.24  0.2531ms  ±0.62%
  whereami.html
   · app() offline                 1,274.89  0.7844ms  ±2.05%
   · extract appSpecs              3,363.46  0.2973ms  ±1.47%