### PR TITLE
feat(core): add request lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,7 +756,7 @@ Pass `throttle` to cap requests per second, and `requestOptions` to override the
 | `retries`            | `number`                         | Retry count for `429` and `5xx`, `0` to `5`. Default `2`.                                                                                                            |
 | `signal`             | `AbortSignal`                    | Cancels the call, including in-flight retries and pagination.                                                                                                        |
 | `onRequest`          | `(event: RequestEvent) => void`  | Called before every attempt, including retries. See [Request lifecycle hooks](#request-lifecycle-hooks).                                                             |
-| `onResponse`         | `(event: ResponseEvent) => void` | Called for every HTTP response, with `status` and `durationMs`.                                                                                                      |
+| `onResponse`         | `(event: ResponseEvent) => void` | Called for each settled response — after the body is read on success — with `status` and `durationMs`.                                                               |
 | `onRetry`            | `(event: RetryEvent) => void`    | Called when a retry is scheduled, with `delayMs` and `reason`.                                                                                                       |
 
 ```typescript
@@ -793,7 +793,7 @@ const details = await app({
 });
 ```
 
-Every event carries `url`, `method`, and a 1-based `attempt`: the first try is attempt 1, a `RetryEvent` carries the number of the attempt that just failed, and the subsequent `RequestEvent` is that attempt plus one. `ResponseEvent` adds `status` and `durationMs`, measured from just before the fetch (throttle wait excluded) and, on success, through the full body transfer. `RetryEvent` adds the scheduled `delayMs`, a `reason` of `'status'` or `'network'`, and the HTTP `status` when the reason is a retryable status. A retry-free happy path emits exactly one `RequestEvent` and one `ResponseEvent`.
+Every event carries `url`, `method`, and a 1-based `attempt`: the first try is attempt 1, a `RetryEvent` carries the number of the attempt that just failed, and the subsequent `RequestEvent` is that attempt plus one. `ResponseEvent` adds `status` and `durationMs`, measured from just before the fetch (throttle wait excluded) and, on success, through the transfer of the full body. `RetryEvent` adds the scheduled `delayMs`, a `reason` of `'status'` or `'network'`, and the HTTP `status` when the reason is a retryable status. A retry-free happy path emits exactly one `RequestEvent` and one `ResponseEvent`.
 
 Hooks are telemetry, never control flow. A hook that throws or returns a rejecting promise is swallowed and the request proceeds unchanged — the deliberate opposite of [`onDegradation`](#monitoring-drift), which rethrows because it is a data-integrity signal. When a client-level and a call-level `requestOptions` set the same hook, the call-level one replaces it for that call; hooks do not chain.
 

--- a/README.md
+++ b/README.md
@@ -748,13 +748,16 @@ An unknown `appId` or `devId` does not fail the same way everywhere, because Goo
 
 Pass `throttle` to cap requests per second, and `requestOptions` to override the HTTP layer:
 
-| requestOptions field | Type                     | Description                                                                                                                                                          |
-| -------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `headers`            | `Record<string, string>` | Extra headers merged into every request.                                                                                                                             |
-| `fetchImpl`          | `typeof fetch`           | A custom `fetch` implementation, useful for proxies and tests. Combine with [`createCountryFetch`](#routing-by-country) to route each storefront country separately. |
-| `timeoutMs`          | `number`                 | Timeout per request, up to `120000`. Default `30000`.                                                                                                                |
-| `retries`            | `number`                 | Retry count for `429` and `5xx`, `0` to `5`. Default `2`.                                                                                                            |
-| `signal`             | `AbortSignal`            | Cancels the call, including in-flight retries and pagination.                                                                                                        |
+| requestOptions field | Type                             | Description                                                                                                                                                          |
+| -------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `headers`            | `Record<string, string>`         | Extra headers merged into every request.                                                                                                                             |
+| `fetchImpl`          | `typeof fetch`                   | A custom `fetch` implementation, useful for proxies and tests. Combine with [`createCountryFetch`](#routing-by-country) to route each storefront country separately. |
+| `timeoutMs`          | `number`                         | Timeout per request, up to `120000`. Default `30000`.                                                                                                                |
+| `retries`            | `number`                         | Retry count for `429` and `5xx`, `0` to `5`. Default `2`.                                                                                                            |
+| `signal`             | `AbortSignal`                    | Cancels the call, including in-flight retries and pagination.                                                                                                        |
+| `onRequest`          | `(event: RequestEvent) => void`  | Called before every attempt, including retries. See [Request lifecycle hooks](#request-lifecycle-hooks).                                                             |
+| `onResponse`         | `(event: ResponseEvent) => void` | Called for every HTTP response, with `status` and `durationMs`.                                                                                                      |
+| `onRetry`            | `(event: RetryEvent) => void`    | Called when a retry is scheduled, with `delayMs` and `reason`.                                                                                                       |
 
 ```typescript
 import { app } from '@mradex77/google-play-scraper';
@@ -772,6 +775,27 @@ const details = await app({
 ```
 
 Retries use exponential backoff and honor a `Retry-After` header when present.
+
+### Request lifecycle hooks
+
+The three `on*` callbacks make request telemetry observable at every level — direct calls, `createClient`, and `memoized` — including what wrapping `fetchImpl` cannot see: retries and backoff decisions.
+
+```typescript
+import { app } from '@mradex77/google-play-scraper';
+
+const details = await app({
+  appId: 'com.google.android.apps.translate',
+  requestOptions: {
+    onRequest: (event) => log.debug('gplay request', event),
+    onResponse: (event) => metrics.timing('gplay.latency', event.durationMs),
+    onRetry: (event) => metrics.increment('gplay.retry', { reason: event.reason }),
+  },
+});
+```
+
+Every event carries `url`, `method`, and a 1-based `attempt`: the first try is attempt 1, a `RetryEvent` carries the number of the attempt that just failed, and the subsequent `RequestEvent` is that attempt plus one. `ResponseEvent` adds `status` and `durationMs`, measured from just before the fetch (throttle wait excluded) and, on success, through the full body transfer. `RetryEvent` adds the scheduled `delayMs`, a `reason` of `'status'` or `'network'`, and the HTTP `status` when the reason is a retryable status. A retry-free happy path emits exactly one `RequestEvent` and one `ResponseEvent`.
+
+Hooks are telemetry, never control flow. A hook that throws or returns a rejecting promise is swallowed and the request proceeds unchanged — the deliberate opposite of [`onDegradation`](#monitoring-drift), which rethrows because it is a data-integrity signal. When a client-level and a call-level `requestOptions` set the same hook, the call-level one replaces it for that call; hooks do not chain.
 
 ### Routing requests through a proxy
 
@@ -878,7 +902,7 @@ Two boundaries to know:
 - An empty continuation page emits nothing: that is the normal end-of-results signal and is indistinguishable from exhaustion.
 - `reviews` pagination never degrades. A parse failure there propagates as a `ParseError`, so review reads fail loudly instead of silently shrinking.
 
-With `memoized()`, `onDegradation` participates in the cache key by identity like any function option, so pass a stable function reference rather than an inline closure to keep cache hits.
+With `memoized()`, `onDegradation` and the lifecycle hooks `onRequest`, `onResponse`, and `onRetry` participate in the cache key by identity like any function option, so pass stable function references rather than inline closures to keep cache hits.
 
 ## Migrating from google-play-scraper
 

--- a/examples/all-methods.ts
+++ b/examples/all-methods.ts
@@ -65,7 +65,20 @@ async function timed<T>(fn: () => Promise<T>): Promise<{ value: T; ms: number }>
 
 async function showApp(): Promise<App> {
   heading('app()', 'detailed information for a single app');
-  const details = await app({ appId: TEST_APP_ID });
+  const details = await app({
+    appId: TEST_APP_ID,
+    requestOptions: {
+      onRequest: (event) => {
+        field('onRequest', `attempt ${String(event.attempt)} ${event.method} ${event.url}`);
+      },
+      onResponse: (event) => {
+        field('onResponse', `status ${String(event.status)} in ${event.durationMs.toFixed(0)}ms`);
+      },
+      onRetry: (event) => {
+        field('onRetry', `${event.reason} retry in ${String(event.delayMs)}ms`);
+      },
+    },
+  });
   field('Title', details.title);
   field('App ID', details.appId);
   field('Developer', details.developer);

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -245,6 +245,41 @@ describe('createClient', () => {
     expect(() => createClient({ throttle: -1 })).toThrow(/^client:/);
   });
 
+  it('fires lifecycle hooks on the throttled shared client', async () => {
+    const requests: number[] = [];
+    const responses: number[] = [];
+    const client = createClient({
+      throttle: 2,
+      requestOptions: {
+        fetchImpl: fetchReturning(translateHtml),
+        onRequest: (event) => {
+          requests.push(event.attempt);
+        },
+        onResponse: (event) => {
+          responses.push(event.status);
+        },
+      },
+    });
+
+    await client.app({ appId: TRANSLATE });
+
+    expect(requests).toEqual([1]);
+    expect(responses).toEqual([200]);
+  });
+
+  it('replaces a client-level hook with a call-level hook instead of chaining', async () => {
+    const clientHook = vi.fn();
+    const callHook = vi.fn();
+    const client = createClient({
+      requestOptions: { fetchImpl: fetchReturning(translateHtml), onRequest: clientHook },
+    });
+
+    await client.app({ appId: TRANSLATE, requestOptions: { onRequest: callHook } });
+
+    expect(callHook).toHaveBeenCalledTimes(1);
+    expect(clientHook).not.toHaveBeenCalled();
+  });
+
   it('leaves the top-level app function unchanged without the client factory', async () => {
     const result = await app({
       appId: TRANSLATE,

--- a/src/client.ts
+++ b/src/client.ts
@@ -74,6 +74,9 @@ export function createClient(options?: ClientOptions): GooglePlayClient & Google
         timeoutMs: requestOptions?.timeoutMs,
         headers: requestOptions?.headers,
         signal: requestOptions?.signal,
+        onRequest: requestOptions?.onRequest,
+        onResponse: requestOptions?.onResponse,
+        onRetry: requestOptions?.onRetry,
       });
     }
     return clientFromOptions({ throttle: opts.throttle, requestOptions });

--- a/src/core/http.test.ts
+++ b/src/core/http.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { clientFromOptions, createHttpClient, createRateLimiter } from './http.js';
+import {
+  clientFromOptions,
+  createHttpClient,
+  createRateLimiter,
+  type OnResponse,
+  type RequestEvent,
+  type ResponseEvent,
+  type RetryEvent,
+} from './http.js';
 import { BlockedError, HttpError, NotFoundError, RateLimitError } from './errors.js';
 
 interface FakeResponseInit {
@@ -334,5 +342,219 @@ describe('createHttpClient', () => {
       .mockResolvedValue(fakeResponse({ body: 'go to www.google.com/recaptcha now' }));
     const captchaClient = createHttpClient({ fetchImpl: captchaFetch });
     await expect(captchaClient.request({ url: 'https://x' })).rejects.toBeInstanceOf(BlockedError);
+  });
+});
+
+type RecordedEvent =
+  | { kind: 'request'; attempt: number }
+  | { kind: 'response'; attempt: number; status: number; durationMs: number }
+  | {
+      kind: 'retry';
+      attempt: number;
+      reason: 'status' | 'network';
+      delayMs: number;
+      status?: number;
+    };
+
+const recordingHooks = (): {
+  events: RecordedEvent[];
+  hooks: {
+    onRequest: (event: RequestEvent) => void;
+    onResponse: (event: ResponseEvent) => void;
+    onRetry: (event: RetryEvent) => void;
+  };
+} => {
+  const events: RecordedEvent[] = [];
+  return {
+    events,
+    hooks: {
+      onRequest: (event) => {
+        events.push({ kind: 'request', attempt: event.attempt });
+      },
+      onResponse: (event) => {
+        events.push({
+          kind: 'response',
+          attempt: event.attempt,
+          status: event.status,
+          durationMs: event.durationMs,
+        });
+      },
+      onRetry: (event) => {
+        events.push({
+          kind: 'retry',
+          attempt: event.attempt,
+          reason: event.reason,
+          delayMs: event.delayMs,
+          status: event.status,
+        });
+      },
+    },
+  };
+};
+
+describe('request lifecycle hooks', () => {
+  it('emits request then response on a first-try success', async () => {
+    const { events, hooks } = recordingHooks();
+    const fetchImpl = vi.fn().mockResolvedValue(fakeResponse({ body: 'ok' }));
+    const client = createHttpClient({ fetchImpl, ...hooks });
+
+    await expect(client.request({ url: 'https://x' })).resolves.toBe('ok');
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ kind: 'request', attempt: 1 });
+    expect(events[1]).toMatchObject({ kind: 'response', attempt: 1, status: 200 });
+    expect((events[1] as { durationMs: number }).durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits a status retry between a 500 and the recovering attempt', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { events, hooks } = recordingHooks();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse({ status: 500 }))
+      .mockResolvedValueOnce(fakeResponse({ body: 'recovered' }));
+    const client = createHttpClient({ fetchImpl, ...hooks });
+
+    const pending = client.request({ url: 'https://x' });
+    await vi.runAllTimersAsync();
+    await expect(pending).resolves.toBe('recovered');
+
+    expect(events.map((event) => event.kind)).toEqual([
+      'request',
+      'response',
+      'retry',
+      'request',
+      'response',
+    ]);
+    expect(events[1]).toMatchObject({ status: 500, attempt: 1 });
+    expect(events[2]).toMatchObject({ reason: 'status', status: 500, attempt: 1 });
+    expect(events[3]).toEqual({ kind: 'request', attempt: 2 });
+    expect(events[4]).toMatchObject({ status: 200, attempt: 2 });
+  });
+
+  it('reports the Retry-After delay in the retry event', async () => {
+    vi.useFakeTimers();
+    const { events, hooks } = recordingHooks();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse({ status: 429, headers: { 'Retry-After': '3' } }))
+      .mockResolvedValueOnce(fakeResponse({ body: 'ok' }));
+    const client = createHttpClient({ fetchImpl, ...hooks });
+
+    const pending = client.request({ url: 'https://x' });
+    await vi.runAllTimersAsync();
+    await pending;
+
+    const retry = events.find((event) => event.kind === 'retry');
+    expect(retry).toMatchObject({ reason: 'status', status: 429, delayMs: 3000 });
+  });
+
+  it('emits a network retry without a status when fetch rejects', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { events, hooks } = recordingHooks();
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('network down'))
+      .mockResolvedValueOnce(fakeResponse({ body: 'ok' }));
+    const client = createHttpClient({ fetchImpl, ...hooks });
+
+    const pending = client.request({ url: 'https://x' });
+    await vi.runAllTimersAsync();
+    await expect(pending).resolves.toBe('ok');
+
+    expect(events.map((event) => event.kind)).toEqual(['request', 'retry', 'request', 'response']);
+    expect(events[1]).toEqual({ kind: 'retry', attempt: 1, reason: 'network', delayMs: 0 });
+  });
+
+  it('emits one response per attempt and one retry per scheduled sleep when exhausted', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { events, hooks } = recordingHooks();
+    const fetchImpl = vi.fn().mockResolvedValue(fakeResponse({ status: 500 }));
+    const client = createHttpClient({ fetchImpl, ...hooks });
+
+    const settled = client.request({ url: 'https://x' }).catch((error: unknown) => error);
+    await vi.runAllTimersAsync();
+    const error = await settled;
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect(events.filter((event) => event.kind === 'request')).toHaveLength(3);
+    expect(events.filter((event) => event.kind === 'response')).toHaveLength(3);
+    expect(events.filter((event) => event.kind === 'retry')).toHaveLength(2);
+    expect(events.map((event) => event.kind)).toEqual([
+      'request',
+      'response',
+      'retry',
+      'request',
+      'response',
+      'retry',
+      'request',
+      'response',
+    ]);
+  });
+
+  it('emits the response before BlockedError propagates for a consent wall', async () => {
+    const { events, hooks } = recordingHooks();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(fakeResponse({ body: 'fine', url: 'https://consent.google.com/m' }));
+    const client = createHttpClient({ fetchImpl, ...hooks });
+
+    await expect(client.request({ url: 'https://x' })).rejects.toBeInstanceOf(BlockedError);
+
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({ kind: 'response', status: 200, attempt: 1 });
+  });
+
+  it('emits no retry event when the caller signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { events, hooks } = recordingHooks();
+    const fetchImpl = abortAwareFetch();
+    const client = createHttpClient({ fetchImpl, signal: controller.signal, ...hooks });
+
+    const error = await client.request({ url: 'https://x' }).catch((caught: unknown) => caught);
+
+    expect((error as DOMException).name).toBe('AbortError');
+    expect(events).toEqual([{ kind: 'request', attempt: 1 }]);
+  });
+
+  it('swallows throwing and rejecting hooks without changing the request', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const retries: RetryEvent[] = [];
+    const onRequest = vi.fn(() => {
+      throw new Error('sync hook failure');
+    });
+    const onResponseMock = vi.fn(() => Promise.reject(new Error('async hook failure')));
+    const onResponse = onResponseMock as unknown as OnResponse;
+    const onRetry = (event: RetryEvent): void => {
+      retries.push(event);
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse({ status: 500 }))
+      .mockResolvedValueOnce(fakeResponse({ body: 'recovered' }));
+    const client = createHttpClient({ fetchImpl, onRequest, onResponse, onRetry });
+
+    const pending = client.request({ url: 'https://x' });
+    await vi.runAllTimersAsync();
+    await expect(pending).resolves.toBe('recovered');
+
+    expect(onRequest).toHaveBeenCalledTimes(2);
+    expect(onResponseMock).toHaveBeenCalledTimes(2);
+    expect(retries).toHaveLength(1);
+  });
+
+  it('threads lifecycle hooks from public request options', async () => {
+    const { events, hooks } = recordingHooks();
+    const fetchImpl = vi.fn().mockResolvedValue(fakeResponse({ body: 'ok' }));
+    const client = clientFromOptions({ requestOptions: { fetchImpl, ...hooks } });
+
+    await client.request({ url: 'https://x' });
+
+    expect(events.map((event) => event.kind)).toEqual(['request', 'response']);
   });
 });

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -16,6 +16,27 @@ export interface HttpRequest {
 
 export type Limiter = () => Promise<void>;
 
+export interface RequestEvent {
+  url: string;
+  method: 'GET' | 'POST';
+  attempt: number;
+}
+
+export interface ResponseEvent extends RequestEvent {
+  status: number;
+  durationMs: number;
+}
+
+export interface RetryEvent extends RequestEvent {
+  delayMs: number;
+  reason: 'status' | 'network';
+  status?: number;
+}
+
+export type OnRequest = (event: RequestEvent) => void;
+export type OnResponse = (event: ResponseEvent) => void;
+export type OnRetry = (event: RetryEvent) => void;
+
 export interface HttpClientConfig {
   fetchImpl?: typeof fetch;
   throttle?: number;
@@ -24,6 +45,9 @@ export interface HttpClientConfig {
   timeoutMs?: number;
   headers?: Record<string, string>;
   signal?: AbortSignal;
+  onRequest?: OnRequest;
+  onResponse?: OnResponse;
+  onRetry?: OnRetry;
 }
 
 export interface HttpClient {
@@ -55,6 +79,20 @@ const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded;charset=UTF-8';
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+
+function emit<Event>(hook: ((event: Event) => unknown) | undefined, event: Event): void {
+  if (hook === undefined) {
+    return;
+  }
+  try {
+    const result = hook(event);
+    if (result instanceof Promise) {
+      result.catch(() => undefined);
+    }
+  } catch {
+    return;
+  }
+}
 
 export function createRateLimiter(rate: number): Limiter {
   let timestamps: number[] = [];
@@ -161,11 +199,18 @@ export function createHttpClient(config: HttpClientConfig = {}): HttpClient {
   const request = async (req: HttpRequest): Promise<string> => {
     const method = req.method ?? 'GET';
     const headers = buildHeaders(method, config.headers, req.headers);
+    const eventFor = (attempt: number): RequestEvent => ({
+      url: req.url,
+      method,
+      attempt: attempt + 1,
+    });
 
     for (let attempt = 0; ; attempt += 1) {
       if (limiter) {
         await limiter();
       }
+      emit(config.onRequest, eventFor(attempt));
+      const startedAt = performance.now();
       try {
         const response = await fetchImpl(req.url, {
           method,
@@ -176,12 +221,30 @@ export function createHttpClient(config: HttpClientConfig = {}): HttpClient {
 
         if (response.ok) {
           const body = await response.text();
+          emit(config.onResponse, {
+            ...eventFor(attempt),
+            status: response.status,
+            durationMs: performance.now() - startedAt,
+          });
           assertNotBlocked(response, body);
           return body;
         }
 
+        emit(config.onResponse, {
+          ...eventFor(attempt),
+          status: response.status,
+          durationMs: performance.now() - startedAt,
+        });
+
         if (isRetryableStatus(response.status) && attempt < retries) {
-          await sleep(computeBackoff(attempt, parseRetryAfter(response)));
+          const delayMs = computeBackoff(attempt, parseRetryAfter(response));
+          emit(config.onRetry, {
+            ...eventFor(attempt),
+            delayMs,
+            reason: 'status',
+            status: response.status,
+          });
+          await sleep(delayMs);
           continue;
         }
 
@@ -194,7 +257,9 @@ export function createHttpClient(config: HttpClientConfig = {}): HttpClient {
           throw error;
         }
         if (attempt < retries) {
-          await sleep(computeBackoff(attempt, undefined));
+          const delayMs = computeBackoff(attempt, undefined);
+          emit(config.onRetry, { ...eventFor(attempt), delayMs, reason: 'network' });
+          await sleep(delayMs);
           continue;
         }
         const httpError = new HttpError(`Network request to ${req.url} failed`, 0, req.url);
@@ -218,5 +283,8 @@ export function clientFromOptions(opts: {
     timeoutMs: opts.requestOptions?.timeoutMs,
     headers: opts.requestOptions?.headers,
     signal: opts.requestOptions?.signal,
+    onRequest: opts.requestOptions?.onRequest,
+    onResponse: opts.requestOptions?.onResponse,
+    onRetry: opts.requestOptions?.onRetry,
   });
 }

--- a/src/core/options.test.ts
+++ b/src/core/options.test.ts
@@ -80,4 +80,29 @@ describe('parseOptions', () => {
 
     expect(parsed.onDegradation).toBeUndefined();
   });
+
+  it('accepts the three lifecycle hooks in request options', () => {
+    const onRequest = (): void => undefined;
+    const onResponse = (): void => undefined;
+    const onRetry = (): void => undefined;
+    const parsed = parseOptions(
+      baseOptionsSchema,
+      { requestOptions: { onRequest, onResponse, onRetry } },
+      'listApps',
+    );
+
+    expect(parsed.requestOptions?.onRequest).toBe(onRequest);
+    expect(parsed.requestOptions?.onResponse).toBe(onResponse);
+    expect(parsed.requestOptions?.onRetry).toBe(onRetry);
+  });
+
+  it('rejects non function lifecycle hooks naming the field', () => {
+    for (const field of ['onRequest', 'onResponse', 'onRetry']) {
+      const act = (): unknown =>
+        parseOptions(baseOptionsSchema, { requestOptions: { [field]: 42 } }, 'listApps');
+
+      expect(act).toThrow(ValidationError);
+      expect(act).toThrow(new RegExp(field));
+    }
+  });
 });

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { OnDegradation } from './degradation.js';
+import type { OnRequest, OnResponse, OnRetry } from './http.js';
 import { ValidationError } from './errors.js';
 
 export const requestOptionsSchema = z.object({
@@ -8,6 +9,9 @@ export const requestOptionsSchema = z.object({
   timeoutMs: z.number().int().positive().max(120000).optional(),
   retries: z.number().int().min(0).max(5).optional(),
   signal: z.custom<AbortSignal>((value) => value instanceof AbortSignal).optional(),
+  onRequest: z.custom<OnRequest>((value) => typeof value === 'function').optional(),
+  onResponse: z.custom<OnResponse>((value) => typeof value === 'function').optional(),
+  onRetry: z.custom<OnRetry>((value) => typeof value === 'function').optional(),
 });
 
 export type RequestOptions = z.infer<typeof requestOptionsSchema>;

--- a/src/features/memoized/memoized.test.ts
+++ b/src/features/memoized/memoized.test.ts
@@ -186,6 +186,23 @@ describe('memoized', () => {
     expect(fetch.state.calls).toBe(4);
   });
 
+  it('keys entries by lifecycle hook identity', async () => {
+    const client = memoized();
+    const fetch = countingAppFetch();
+    const stableHook = (): void => undefined;
+    const requestOptionsWith = (onRequest: () => void): RequestOptions => ({
+      fetchImpl: fetch.fetchImpl,
+      onRequest,
+    });
+
+    await client.app({ appId: 'com.a', requestOptions: requestOptionsWith(stableHook) });
+    await client.app({ appId: 'com.a', requestOptions: requestOptionsWith(stableHook) });
+    expect(fetch.state.calls).toBe(1);
+
+    await client.app({ appId: 'com.a', requestOptions: requestOptionsWith((): void => undefined) });
+    expect(fetch.state.calls).toBe(2);
+  });
+
   it('memoizes methods that take no options and exposes the constants', async () => {
     const client = memoized();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,15 @@ export type { SpecFailure } from './core/errors.js';
 
 export type { DegradationEvent, OnDegradation } from './core/degradation.js';
 
+export type {
+  OnRequest,
+  OnResponse,
+  OnRetry,
+  RequestEvent,
+  ResponseEvent,
+  RetryEvent,
+} from './core/http.js';
+
 export { createCountryFetch, countryFetchSettingsSchema } from './core/countryFetch.js';
 export type { CountryFetchSettings } from './core/countryFetch.js';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request lifecycle hooks (`onRequest`, `onResponse`, `onRetry`) with emitted event data for request attempts, responses, and retries.
  * Exposed corresponding event and callback types in the public API.
  * Added an example demonstrating request instrumentation.
* **Documentation**
  * Updated README with hook timing/semantics, payload details, precedence behavior, hook error handling, and memoization/monitoring drift guidance.
* **Bug Fixes**
  * Ensured client and per-call lifecycle hooks are correctly wired, including call-level precedence over client-level.
* **Tests**
  * Added coverage for hook ordering, retry delay/reason logic, abort/blocked scenarios, and swallowed hook failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->