### PR TITLE
feat(cli): add a google-play-scraper command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npx @mradex77/google-play-scraper availability com.adex77.WhereAmI --countries u
 | `categories`           |                         |                                                                 |
 | `availability <appId>` | app id                  | `--countries` (comma-separated, required), `--concurrency`      |
 
-Every command also accepts `--lang <code>`, `--country <code>` and `--throttle <requestsPerSecond>`, plus the global `--help` and `--version`.
+Every command also accepts `--lang <code>`, `--country <code>` and `--throttle <requestsPerSecond>`, plus `--help`/`-h` (global or per command) and the global `--version`.
 
 Results are pretty-printed JSON on stdout, so the output pipes straight into `jq`:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This is a modern TypeScript rewrite of the popular but unmaintained [`google-pla
 ## Table of contents
 
 - [Installation](#installation)
+- [CLI](#cli)
 - [Quick start](#quick-start)
 - [Common options](#common-options)
 - [Shared client](#shared-client)
@@ -66,6 +67,42 @@ npm install @mradex77/google-play-scraper
 ```
 
 Requires Node.js 22.12 or newer.
+
+## CLI
+
+Every method with a JSON-friendly surface is also available from the command line, no install required:
+
+```sh
+npx @mradex77/google-play-scraper app com.spotify.music
+npx @mradex77/google-play-scraper search "sleep tracker" --num 5 --country de
+npx @mradex77/google-play-scraper reviews com.mojang.minecraftpe --sort rating --num 20
+npx @mradex77/google-play-scraper availability com.adex77.WhereAmI --countries us,pl,de
+```
+
+| Command                | Positional              | Own flags                                                       |
+| ---------------------- | ----------------------- | --------------------------------------------------------------- |
+| `app <appId>`          | app id                  |                                                                 |
+| `apps <appIds>`        | comma-separated app ids | `--concurrency`                                                 |
+| `search <term>`        | search term             | `--num`, `--price`, `--full-detail`                             |
+| `suggest <term>`       | search term             |                                                                 |
+| `list`                 |                         | `--collection`, `--category`, `--age`, `--num`, `--full-detail` |
+| `developer <devId>`    | developer id            | `--num`, `--full-detail`                                        |
+| `similar <appId>`      | app id                  | `--full-detail`                                                 |
+| `reviews <appId>`      | app id                  | `--num`, `--sort`, `--paginate`, `--token`                      |
+| `permissions <appId>`  | app id                  | `--short`                                                       |
+| `datasafety <appId>`   | app id                  |                                                                 |
+| `categories`           |                         |                                                                 |
+| `availability <appId>` | app id                  | `--countries` (comma-separated, required), `--concurrency`      |
+
+Every command also accepts `--lang <code>`, `--country <code>` and `--throttle <requestsPerSecond>`, plus the global `--help` and `--version`.
+
+Results are pretty-printed JSON on stdout, so the output pipes straight into `jq`:
+
+```sh
+npx @mradex77/google-play-scraper app com.spotify.music | jq '{title, score, installs}'
+```
+
+Exit codes: `0` success, `1` scrape failure (not found, rate limited, blocked, network), `2` usage error (unknown command or flag, missing argument, invalid option value).
 
 ## Quick start
 

--- a/e2e/cli.e2e.test.ts
+++ b/e2e/cli.e2e.test.ts
@@ -12,6 +12,8 @@ const GEO_GAME_ID = 'com.adex77.WhereAmI';
 const MISSING_ID = 'com.adex77.definitely.not.a.real.app';
 const GOOGLE_DEV_ID = '5700313618786177705';
 
+const CLI_PROCESS_TIMEOUT_MS = 25000;
+
 interface CliRun {
   exitCode: number;
   stdout: string;
@@ -23,7 +25,7 @@ function runCliProcess(args: readonly string[]): Promise<CliRun> {
     execFile(
       process.execPath,
       ['--import', 'tsx', 'src/cli/main.ts', ...args],
-      { cwd: REPO_ROOT, encoding: 'utf8' },
+      { cwd: REPO_ROOT, encoding: 'utf8', timeout: CLI_PROCESS_TIMEOUT_MS },
       (error, stdout, stderr) => {
         const exitCode = error === null ? 0 : typeof error.code === 'number' ? error.code : 1;
         resolve({ exitCode, stdout, stderr });

--- a/e2e/cli.e2e.test.ts
+++ b/e2e/cli.e2e.test.ts
@@ -1,0 +1,60 @@
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from 'vitest';
+import { liveDescribe } from './helpers.js';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+interface CliRun {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCliProcess(args: readonly string[]): Promise<CliRun> {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      ['--import', 'tsx', 'src/cli/main.ts', ...args],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+      (error, stdout, stderr) => {
+        const exitCode = error === null ? 0 : typeof error.code === 'number' ? error.code : 1;
+        resolve({ exitCode, stdout, stderr });
+      },
+    );
+  });
+}
+
+liveDescribe('cli', () => {
+  it('app prints the app detail as JSON and exits 0', async () => {
+    const { exitCode, stdout } = await runCliProcess(['app', 'com.google.android.apps.translate']);
+    expect(exitCode).toBe(0);
+    const parsed: unknown = JSON.parse(stdout);
+    expect(parsed).toMatchObject({ appId: 'com.google.android.apps.translate' });
+    expect(parsed).toHaveProperty('title', expect.any(String));
+    const detail = parsed as { title: string };
+    expect(detail.title.length).toBeGreaterThan(0);
+  });
+
+  it('app exits 1 for a missing app and mentions not found on stderr', async () => {
+    const { exitCode, stdout, stderr } = await runCliProcess([
+      'app',
+      'com.an.app.that.does.not.exist.xyz',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr.toLowerCase()).toContain('not found');
+  });
+
+  it('suggest prints a JSON array and exits 0', async () => {
+    const { exitCode, stdout } = await runCliProcess(['suggest', 'panda', '--country', 'us']);
+    expect(exitCode).toBe(0);
+    const parsed: unknown = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    const suggestions = parsed as string[];
+    expect(suggestions.length).toBeGreaterThan(0);
+    for (const suggestion of suggestions) {
+      expect(typeof suggestion).toBe('string');
+    }
+  });
+});

--- a/e2e/cli.e2e.test.ts
+++ b/e2e/cli.e2e.test.ts
@@ -6,6 +6,12 @@ import { liveDescribe } from './helpers.js';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
+const TRANSLATE_ID = 'com.google.android.apps.translate';
+const INSTAGRAM_ID = 'com.instagram.android';
+const GEO_GAME_ID = 'com.adex77.WhereAmI';
+const MISSING_ID = 'com.adex77.definitely.not.a.real.app';
+const GOOGLE_DEV_ID = '5700313618786177705';
+
 interface CliRun {
   exitCode: number;
   stdout: string;
@@ -26,12 +32,18 @@ function runCliProcess(args: readonly string[]): Promise<CliRun> {
   });
 }
 
+async function runCliJson(args: readonly string[]): Promise<unknown> {
+  const { exitCode, stdout } = await runCliProcess(args);
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout) as unknown;
+}
+
 liveDescribe('cli', () => {
   it('app prints the app detail as JSON and exits 0', async () => {
-    const { exitCode, stdout } = await runCliProcess(['app', 'com.google.android.apps.translate']);
+    const { exitCode, stdout } = await runCliProcess(['app', TRANSLATE_ID]);
     expect(exitCode).toBe(0);
     const parsed: unknown = JSON.parse(stdout);
-    expect(parsed).toMatchObject({ appId: 'com.google.android.apps.translate' });
+    expect(parsed).toMatchObject({ appId: TRANSLATE_ID });
     expect(parsed).toHaveProperty('title', expect.any(String));
     const detail = parsed as { title: string };
     expect(detail.title.length).toBeGreaterThan(0);
@@ -70,6 +82,184 @@ liveDescribe('cli', () => {
     for (const result of results) {
       expect(typeof result.appId).toBe('string');
     }
+  });
+});
+
+liveDescribe('cli commands against live google play', () => {
+  it('apps fetches a batch in order with fulfilled entries', async () => {
+    const parsed = await runCliJson([
+      'apps',
+      `${TRANSLATE_ID},${INSTAGRAM_ID}`,
+      '--concurrency',
+      '2',
+    ]);
+    const entries = parsed as { appId: string; status: string; app?: { appId: string } }[];
+    expect(entries.map((entry) => entry.appId)).toEqual([TRANSLATE_ID, INSTAGRAM_ID]);
+    for (const entry of entries) {
+      expect(entry.status).toBe('fulfilled');
+      expect(entry.app?.appId).toBe(entry.appId);
+    }
+  });
+
+  it('apps reports a missing id as rejected without failing the batch', async () => {
+    const parsed = await runCliJson(['apps', `${TRANSLATE_ID},${MISSING_ID}`]);
+    const entries = parsed as { appId: string; status: string }[];
+    expect(entries[0]?.status).toBe('fulfilled');
+    expect(entries[1]?.status).toBe('rejected');
+    expect(entries[1]?.appId).toBe(MISSING_ID);
+  });
+
+  it('list returns the requested number of free games', async () => {
+    const parsed = await runCliJson([
+      'list',
+      '--collection',
+      'TOP_FREE',
+      '--category',
+      'GAME',
+      '--num',
+      '5',
+    ]);
+    const items = parsed as { appId: string; free: boolean; price: number }[];
+    expect(items).toHaveLength(5);
+    for (const item of items) {
+      expect(item.appId.length).toBeGreaterThan(0);
+      expect(item.free).toBe(true);
+      expect(item.price).toBe(0);
+    }
+  });
+
+  it('developer lists google apps for the numeric dev id', async () => {
+    const parsed = await runCliJson(['developer', GOOGLE_DEV_ID, '--num', '10']);
+    const items = parsed as { appId: string; developer: string }[];
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.developer).toContain('Google');
+    }
+  });
+
+  it('similar excludes the source app', async () => {
+    const parsed = await runCliJson(['similar', GEO_GAME_ID]);
+    const items = parsed as { appId: string }[];
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.some((item) => item.appId === GEO_GAME_ID)).toBe(false);
+  });
+
+  it('similar exits 1 for a missing app because it is an html surface', async () => {
+    const { exitCode, stdout, stderr } = await runCliProcess(['similar', MISSING_ID]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr.toLowerCase()).toContain('not found');
+  });
+
+  it('reviews accumulates exactly --num reviews with valid scores', async () => {
+    const parsed = await runCliJson(['reviews', TRANSLATE_ID, '--num', '5', '--sort', 'rating']);
+    const result = parsed as { data: { id: string; score: number }[] };
+    expect(result.data).toHaveLength(5);
+    for (const review of result.data) {
+      expect(review.id.length).toBeGreaterThan(0);
+      expect(review.score).toBeGreaterThanOrEqual(1);
+      expect(review.score).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it('reviews resumes from a --token onto a different page', async () => {
+    const first = (await runCliJson(['reviews', TRANSLATE_ID, '--paginate'])) as {
+      data: { id: string }[];
+      nextPaginationToken: string | null;
+    };
+    expect(first.data.length).toBeGreaterThan(0);
+    expect(first.nextPaginationToken).not.toBeNull();
+    const second = (await runCliJson([
+      'reviews',
+      TRANSLATE_ID,
+      '--paginate',
+      '--token',
+      first.nextPaginationToken ?? '',
+    ])) as { data: { id: string }[] };
+    expect(second.data.length).toBeGreaterThan(0);
+    expect(second.data[0]?.id).not.toBe(first.data[0]?.id);
+  });
+
+  it('permissions --short prints plain permission strings', async () => {
+    const parsed = await runCliJson(['permissions', TRANSLATE_ID, '--short']);
+    const names = parsed as string[];
+    expect(names.length).toBeGreaterThan(3);
+    for (const name of names) {
+      expect(typeof name).toBe('string');
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('permissions prints an empty array for a missing app and exits 0', async () => {
+    const { exitCode, stdout, stderr } = await runCliProcess(['permissions', MISSING_ID]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(JSON.parse(stdout)).toEqual([]);
+  });
+
+  it('datasafety reports collected data and a privacy policy url', async () => {
+    const parsed = await runCliJson(['datasafety', TRANSLATE_ID]);
+    const report = parsed as {
+      collectedData: { data: string }[];
+      securityPractices: { practice: string }[];
+      privacyPolicyUrl?: string;
+    };
+    expect(report.collectedData.length).toBeGreaterThan(0);
+    expect(report.securityPractices.length).toBeGreaterThan(0);
+    expect(report.privacyPolicyUrl?.startsWith('http')).toBe(true);
+  });
+
+  it('datasafety prints an empty report for a missing app and exits 0', async () => {
+    const parsed = await runCliJson(['datasafety', MISSING_ID]);
+    const report = parsed as Record<string, unknown>;
+    expect(report.sharedData).toEqual([]);
+    expect(report.collectedData).toEqual([]);
+    expect(report.securityPractices).toEqual([]);
+    expect(report).not.toHaveProperty('privacyPolicyUrl');
+  });
+
+  it('categories prints the taxonomy including GAME and APPLICATION', async () => {
+    const parsed = await runCliJson(['categories']);
+    const ids = parsed as string[];
+    expect(ids.length).toBeGreaterThan(30);
+    expect(ids).toContain('GAME');
+    expect(ids).toContain('APPLICATION');
+    for (const id of ids) {
+      expect(id).toMatch(/^[A-Z_0-9]+$/);
+    }
+  });
+
+  it('availability reports the canonical app available in us and pl', async () => {
+    const parsed = await runCliJson([
+      'availability',
+      GEO_GAME_ID,
+      '--countries',
+      'us,PL',
+      '--concurrency',
+      '2',
+    ]);
+    const result = parsed as {
+      appId: string;
+      countries: Record<string, { status: string } | undefined>;
+    };
+    expect(result.appId).toBe(GEO_GAME_ID);
+    expect(result.countries.us?.status).toBe('available');
+    expect(result.countries.pl?.status).toBe('available');
+  });
+
+  it('app honors --lang and --country', async () => {
+    const parsed = await runCliJson(['app', TRANSLATE_ID, '--lang', 'de', '--country', 'de']);
+    const detail = parsed as { appId: string; title: string };
+    expect(detail.appId).toBe(TRANSLATE_ID);
+    expect(detail.title.length).toBeGreaterThan(0);
+  });
+
+  it('search --full-detail returns results carrying full app fields', async () => {
+    const parsed = await runCliJson(['search', 'panda', '--num', '1', '--full-detail']);
+    const results = parsed as { appId: string; description?: string }[];
+    expect(results).toHaveLength(1);
+    expect(results[0]?.appId.length).toBeGreaterThan(0);
+    expect(results[0]?.description?.length).toBeGreaterThan(0);
   });
 });
 

--- a/e2e/cli.e2e.test.ts
+++ b/e2e/cli.e2e.test.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { liveDescribe } from './helpers.js';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
@@ -56,5 +57,73 @@ liveDescribe('cli', () => {
     for (const suggestion of suggestions) {
       expect(typeof suggestion).toBe('string');
     }
+  });
+
+  it('search respects --num and every result carries an appId', async () => {
+    const { exitCode, stdout } = await runCliProcess(['search', 'panda', '--num', '3']);
+    expect(exitCode).toBe(0);
+    const parsed: unknown = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    const results = parsed as { appId?: string }[];
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.length).toBeLessThanOrEqual(3);
+    for (const result of results) {
+      expect(typeof result.appId).toBe('string');
+    }
+  });
+});
+
+describe('cli process contract', () => {
+  it('--help exits 0 and lists the commands', async () => {
+    const { exitCode, stdout, stderr } = await runCliProcess(['--help']);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    for (const name of ['app', 'search', 'reviews', 'availability', 'datasafety']) {
+      expect(stdout).toContain(name);
+    }
+  });
+
+  it('--version exits 0 and prints the package version', async () => {
+    const raw = await readFile(new URL('../package.json', import.meta.url), 'utf8');
+    const { version } = JSON.parse(raw) as { version: string };
+    const { exitCode, stdout } = await runCliProcess(['--version']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe(`${version}\n`);
+  });
+
+  it('an unknown command exits 2 and prints usage on stderr', async () => {
+    const { exitCode, stdout, stderr } = await runCliProcess(['frobnicate']);
+    expect(exitCode).toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('unknown command "frobnicate"');
+    expect(stderr).toContain('Usage: google-play-scraper <command>');
+  });
+
+  it('an unknown flag exits 2 and prints the command usage', async () => {
+    const { exitCode, stdout, stderr } = await runCliProcess(['app', 'com.example', '--nope']);
+    expect(exitCode).toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('Usage: google-play-scraper app <appId>');
+  });
+
+  it('a missing required positional exits 2 without touching the network', async () => {
+    const { exitCode, stdout, stderr } = await runCliProcess(['app']);
+    expect(exitCode).toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('missing required argument');
+  });
+
+  it('a garbage --num exits 2 with the validation message', async () => {
+    const { exitCode, stdout, stderr } = await runCliProcess(['search', 'panda', '--num', 'abc']);
+    expect(exitCode).toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('num');
+  });
+
+  it('a missing --countries exits 2 with the usage line', async () => {
+    const { exitCode, stderr } = await runCliProcess(['availability', 'com.example']);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('--countries is required');
+    expect(stderr).toContain('Usage: google-play-scraper availability <appId>');
   });
 });

--- a/e2e/cli.e2e.test.ts
+++ b/e2e/cli.e2e.test.ts
@@ -12,7 +12,7 @@ const GEO_GAME_ID = 'com.adex77.WhereAmI';
 const MISSING_ID = 'com.adex77.definitely.not.a.real.app';
 const GOOGLE_DEV_ID = '5700313618786177705';
 
-const CLI_PROCESS_TIMEOUT_MS = 25000;
+const CLI_PROCESS_TIMEOUT_MS = 30000;
 
 interface CliRun {
   exitCode: number;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "market-research",
     "typescript",
     "nodejs",
-    "zod"
+    "zod",
+    "cli"
   ],
   "homepage": "https://github.com/MrAdex77/google-play-scraper#readme",
   "repository": {
@@ -43,6 +44,9 @@
     "node": ">=22.12.0"
   },
   "packageManager": "pnpm@11.10.0",
+  "bin": {
+    "google-play-scraper": "./dist/cli.js"
+  },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1,0 +1,193 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { NotFoundError } from '../core/errors.js';
+import { runCli } from './cli.js';
+import { commands } from './commands.js';
+import type { CliApi } from './commands.js';
+
+interface RecordedIo {
+  io: { out: (text: string) => void; err: (text: string) => void };
+  stdout: () => string;
+  stderr: () => string;
+}
+
+function createIo(): RecordedIo {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    io: {
+      out: (text) => {
+        out.push(text);
+      },
+      err: (text) => {
+        err.push(text);
+      },
+    },
+    stdout: () => out.join(''),
+    stderr: () => err.join(''),
+  };
+}
+
+const API_METHODS = [
+  'app',
+  'apps',
+  'search',
+  'suggest',
+  'list',
+  'developer',
+  'similar',
+  'reviews',
+  'permissions',
+  'datasafety',
+  'categories',
+  'availability',
+] as const;
+
+function createStubApi(result: unknown = { stub: true }): {
+  api: CliApi;
+  calls: { method: string; options: unknown }[];
+} {
+  const calls: { method: string; options: unknown }[] = [];
+  const api = Object.fromEntries(
+    API_METHODS.map((method) => [
+      method,
+      (options: unknown) => {
+        calls.push({ method, options });
+        return Promise.resolve(result);
+      },
+    ]),
+  ) as unknown as CliApi;
+  return { api, calls };
+}
+
+describe('runCli success path', () => {
+  it('prints the pretty JSON result with a trailing newline and returns 0', async () => {
+    const value = { appId: 'com.example', title: 'Example' };
+    const { api } = createStubApi(value);
+    const { io, stdout, stderr } = createIo();
+    const code = await runCli(['app', 'com.example'], io, api);
+    expect(code).toBe(0);
+    expect(stdout()).toBe(`${JSON.stringify(value, null, 2)}\n`);
+    expect(stderr()).toBe('');
+  });
+
+  it('dispatches the positional and flags through to the api', async () => {
+    const { api, calls } = createStubApi();
+    const { io } = createIo();
+    await runCli(['reviews', 'com.example', '--sort', 'rating', '--num', '20'], io, api);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe('reviews');
+    expect(calls[0]?.options).toMatchObject({ appId: 'com.example', num: 20, sort: 3 });
+  });
+});
+
+describe('runCli scrape failures', () => {
+  it('returns 1 and writes the message to stderr on NotFoundError', async () => {
+    const { api } = createStubApi();
+    api.app = () =>
+      Promise.reject(new NotFoundError('App not found (404)', 404, 'https://example.com'));
+    const { io, stdout, stderr } = createIo();
+    const code = await runCli(['app', 'com.example'], io, api);
+    expect(code).toBe(1);
+    expect(stdout()).toBe('');
+    expect(stderr()).toContain('App not found (404)');
+  });
+});
+
+describe('runCli usage errors', () => {
+  it('returns 2 for an unknown command and prints the help', async () => {
+    const { api } = createStubApi();
+    const { io, stdout, stderr } = createIo();
+    const code = await runCli(['frobnicate'], io, api);
+    expect(code).toBe(2);
+    expect(stdout()).toBe('');
+    expect(stderr()).toContain('unknown command "frobnicate"');
+    expect(stderr()).toContain('Usage: google-play-scraper <command>');
+  });
+
+  it('returns 2 for an unknown flag and prints the command usage', async () => {
+    const { api } = createStubApi();
+    const { io, stderr } = createIo();
+    const code = await runCli(['app', 'com.example', '--nope'], io, api);
+    expect(code).toBe(2);
+    expect(stderr()).toContain('google-play-scraper:');
+    expect(stderr()).toContain('Usage: google-play-scraper app <appId>');
+  });
+
+  it('returns 2 for a missing required positional and prints the usage', async () => {
+    const { api, calls } = createStubApi();
+    const { io, stderr } = createIo();
+    const code = await runCli(['app'], io, api);
+    expect(code).toBe(2);
+    expect(calls).toEqual([]);
+    expect(stderr()).toContain('missing required argument');
+    expect(stderr()).toContain('Usage: google-play-scraper app <appId>');
+  });
+
+  it('returns 2 with no arguments at all and prints the help to stderr', async () => {
+    const { api } = createStubApi();
+    const { io, stdout, stderr } = createIo();
+    const code = await runCli([], io, api);
+    expect(code).toBe(2);
+    expect(stdout()).toBe('');
+    expect(stderr()).toContain('Usage: google-play-scraper <command>');
+  });
+
+  it('surfaces a feature ValidationError for a garbage --num as exit 2', async () => {
+    const { io, stdout, stderr } = createIo();
+    const code = await runCli(['search', 'panda', '--num', 'abc'], io);
+    expect(code).toBe(2);
+    expect(stdout()).toBe('');
+    expect(stderr()).toContain('num');
+    expect(stderr()).toContain('Usage: google-play-scraper search <term>');
+  });
+
+  it('returns 2 for an unknown sort naming the valid choices', async () => {
+    const { api } = createStubApi();
+    const { io, stderr } = createIo();
+    const code = await runCli(['reviews', 'com.example', '--sort', 'banana'], io, api);
+    expect(code).toBe(2);
+    expect(stderr()).toContain('sort must be one of newest, rating, helpfulness');
+  });
+
+  it('returns 2 for a missing --countries and prints the usage line', async () => {
+    const { api } = createStubApi();
+    const { io, stderr } = createIo();
+    const code = await runCli(['availability', 'com.example'], io, api);
+    expect(code).toBe(2);
+    expect(stderr()).toContain('--countries is required');
+    expect(stderr()).toContain('Usage: google-play-scraper availability <appId>');
+  });
+});
+
+describe('runCli global flags', () => {
+  it('--help lists every command from the table and returns 0', async () => {
+    const { api } = createStubApi();
+    const { io, stdout, stderr } = createIo();
+    const code = await runCli(['--help'], io, api);
+    expect(code).toBe(0);
+    expect(stderr()).toBe('');
+    for (const command of commands) {
+      expect(stdout()).toContain(command.name);
+    }
+  });
+
+  it('<command> --help prints that command usage and returns 0', async () => {
+    const { api, calls } = createStubApi();
+    const { io, stdout } = createIo();
+    const code = await runCli(['search', '--help'], io, api);
+    expect(code).toBe(0);
+    expect(calls).toEqual([]);
+    expect(stdout()).toContain('Usage: google-play-scraper search <term>');
+  });
+
+  it('--version prints the exact version from package.json and returns 0', async () => {
+    const raw = await readFile(new URL('../../package.json', import.meta.url), 'utf8');
+    const { version } = JSON.parse(raw) as { version: string };
+    const { api } = createStubApi();
+    const { io, stdout } = createIo();
+    const code = await runCli(['--version'], io, api);
+    expect(code).toBe(0);
+    expect(stdout()).toBe(`${version}\n`);
+  });
+});

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -200,6 +200,23 @@ describe('runCli global flags', () => {
     expect(stdout()).toContain('Usage: google-play-scraper search <term>');
   });
 
+  it('-h prints the global help and returns 0', async () => {
+    const { api } = createStubApi();
+    const { io, stdout } = createIo();
+    const code = await runCli(['-h'], io, api);
+    expect(code).toBe(0);
+    expect(stdout()).toContain('Usage: google-play-scraper <command>');
+  });
+
+  it('<command> -h prints that command usage and returns 0', async () => {
+    const { api, calls } = createStubApi();
+    const { io, stdout } = createIo();
+    const code = await runCli(['app', 'com.example', '-h'], io, api);
+    expect(code).toBe(0);
+    expect(calls).toEqual([]);
+    expect(stdout()).toContain('Usage: google-play-scraper app <appId>');
+  });
+
   it('--version prints the exact version from package.json and returns 0', async () => {
     const raw = await readFile(new URL('../../package.json', import.meta.url), 'utf8');
     const { version } = JSON.parse(raw) as { version: string };

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
-import { NotFoundError } from '../core/errors.js';
+import { GooglePlayError, NotFoundError } from '../core/errors.js';
 import { runCli } from './cli.js';
 import { commands } from './commands.js';
 import type { CliApi } from './commands.js';
@@ -92,6 +92,27 @@ describe('runCli scrape failures', () => {
     expect(stdout()).toBe('');
     expect(stderr()).toContain('App not found (404)');
   });
+
+  it('returns 1 for a plain GooglePlayError with its message on stderr', async () => {
+    const { api } = createStubApi();
+    api.search = () => Promise.reject(new GooglePlayError('rate limited by google play'));
+    const { io, stdout, stderr } = createIo();
+    const code = await runCli(['search', 'panda'], io, api);
+    expect(code).toBe(1);
+    expect(stdout()).toBe('');
+    expect(stderr()).toContain('rate limited by google play');
+  });
+
+  it('returns 1 and stringifies a non-Error rejection', async () => {
+    const { api } = createStubApi();
+    const rejection = 'boom' as unknown as Error;
+    api.app = () => Promise.reject(rejection);
+    const { io, stdout, stderr } = createIo();
+    const code = await runCli(['app', 'com.example'], io, api);
+    expect(code).toBe(1);
+    expect(stdout()).toBe('');
+    expect(stderr()).toContain('boom');
+  });
 });
 
 describe('runCli usage errors', () => {
@@ -176,6 +197,102 @@ describe('runCli usage errors', () => {
     expect(code).toBe(2);
     expect(stderr()).toContain('--countries is required');
     expect(stderr()).toContain('Usage: google-play-scraper availability <appId>');
+  });
+
+  it('returns 2 when a string flag is missing its value', async () => {
+    const { api, calls } = createStubApi();
+    const { io, stderr } = createIo();
+    const code = await runCli(['search', 'panda', '--num'], io, api);
+    expect(code).toBe(2);
+    expect(calls).toEqual([]);
+    expect(stderr()).toContain('Usage: google-play-scraper search <term>');
+  });
+
+  it('surfaces a feature ValidationError for a garbage --throttle as exit 2', async () => {
+    const { io, stdout, stderr } = createIo();
+    const code = await runCli(['app', 'com.example', '--throttle', 'abc'], io);
+    expect(code).toBe(2);
+    expect(stdout()).toBe('');
+    expect(stderr()).toContain('throttle');
+  });
+
+  it('surfaces a feature ValidationError for a negative --num as exit 2', async () => {
+    const { io, stderr } = createIo();
+    const code = await runCli(['search', 'panda', '--num', '-5'], io);
+    expect(code).toBe(2);
+    expect(stderr()).toContain('num');
+  });
+
+  it('surfaces the feature ValidationError for an empty apps list as exit 2', async () => {
+    const { io, stderr } = createIo();
+    const code = await runCli(['apps', ','], io);
+    expect(code).toBe(2);
+    expect(stderr()).toContain('appIds');
+  });
+
+  it('surfaces the feature ValidationError for duplicate countries as exit 2', async () => {
+    const { io, stderr } = createIo();
+    const code = await runCli(['availability', 'com.example', '--countries', 'us,US'], io);
+    expect(code).toBe(2);
+    expect(stderr()).toContain('unique');
+  });
+
+  it('surfaces the feature ValidationError for a malformed country code as exit 2', async () => {
+    const { io, stderr } = createIo();
+    const code = await runCli(['availability', 'com.example', '--countries', 'usa'], io);
+    expect(code).toBe(2);
+    expect(stderr()).toContain('countries');
+  });
+
+  it('returns 2 for an unknown --collection naming the valid choices', async () => {
+    const { api, calls } = createStubApi();
+    const { io, stderr } = createIo();
+    const code = await runCli(['list', '--collection', 'TOP_BANANA'], io, api);
+    expect(code).toBe(2);
+    expect(calls).toEqual([]);
+    expect(stderr()).toContain('collection must be one of TOP_FREE, TOP_PAID, GROSSING');
+  });
+
+  it('returns 2 for an unknown --price naming the valid choices', async () => {
+    const { api } = createStubApi();
+    const { io, stderr } = createIo();
+    const code = await runCli(['search', 'panda', '--price', 'cheap'], io, api);
+    expect(code).toBe(2);
+    expect(stderr()).toContain('price must be one of all, free, paid');
+  });
+});
+
+describe('runCli parsing details', () => {
+  it('lets the last repeated flag value win', async () => {
+    const { api, calls } = createStubApi();
+    const { io } = createIo();
+    const code = await runCli(['search', 'panda', '--num', '5', '--num', '7'], io, api);
+    expect(code).toBe(0);
+    expect(calls[0]?.options).toMatchObject({ num: 7 });
+  });
+
+  it('treats arguments after -- as positionals', async () => {
+    const { api, calls } = createStubApi();
+    const { io } = createIo();
+    const code = await runCli(['app', '--', 'com.example'], io, api);
+    expect(code).toBe(0);
+    expect(calls[0]?.options).toMatchObject({ appId: 'com.example' });
+  });
+
+  it('accepts the --flag=value form', async () => {
+    const { api, calls } = createStubApi();
+    const { io } = createIo();
+    const code = await runCli(['search', 'panda', '--num=9', '--country=de'], io, api);
+    expect(code).toBe(0);
+    expect(calls[0]?.options).toMatchObject({ num: 9, country: 'de' });
+  });
+
+  it('keeps a multi-word quoted term as one positional', async () => {
+    const { api, calls } = createStubApi();
+    const { io } = createIo();
+    const code = await runCli(['search', 'sleep tracker'], io, api);
+    expect(code).toBe(0);
+    expect(calls[0]?.options).toMatchObject({ term: 'sleep tracker' });
   });
 });
 

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -124,6 +124,25 @@ describe('runCli usage errors', () => {
     expect(stderr()).toContain('Usage: google-play-scraper app <appId>');
   });
 
+  it('returns 2 for an unexpected extra positional and names it', async () => {
+    const { api, calls } = createStubApi();
+    const { io, stderr } = createIo();
+    const code = await runCli(['app', 'com.example', 'com.stray'], io, api);
+    expect(code).toBe(2);
+    expect(calls).toEqual([]);
+    expect(stderr()).toContain('unexpected argument "com.stray"');
+    expect(stderr()).toContain('Usage: google-play-scraper app <appId>');
+  });
+
+  it('returns 2 when a command that takes no positional receives one', async () => {
+    const { api, calls } = createStubApi();
+    const { io, stderr } = createIo();
+    const code = await runCli(['list', 'com.example'], io, api);
+    expect(code).toBe(2);
+    expect(calls).toEqual([]);
+    expect(stderr()).toContain('unexpected argument "com.example"');
+  });
+
   it('returns 2 with no arguments at all and prints the help to stderr', async () => {
     const { api } = createStubApi();
     const { io, stdout, stderr } = createIo();

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -55,6 +55,15 @@ function usageFailure(io: CliIo, message: string, command: CliCommand | undefine
   return 2;
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function scrapeFailure(io: CliIo, error: unknown): 1 {
+  io.err(`${BIN_NAME}: ${errorMessage(error)}\n`);
+  return 1;
+}
+
 function isParseArgsError(error: unknown): error is TypeError & { code: string } {
   return (
     error instanceof TypeError &&
@@ -79,8 +88,12 @@ export async function runCli(
     return 0;
   }
   if (first === '--version') {
-    io.out(`${await readVersion()}\n`);
-    return 0;
+    try {
+      io.out(`${await readVersion()}\n`);
+      return 0;
+    } catch (error) {
+      return scrapeFailure(io, error);
+    }
   }
   const command = commands.find((entry) => entry.name === first);
   if (command === undefined) {
@@ -124,8 +137,6 @@ export async function runCli(
     if (error instanceof ValidationError) {
       return usageFailure(io, error.message, command);
     }
-    const message = error instanceof Error ? error.message : String(error);
-    io.err(`${BIN_NAME}: ${message}\n`);
-    return 1;
+    return scrapeFailure(io, error);
   }
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,0 +1,126 @@
+import { readFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+import { z } from 'zod';
+import gplay from '../index.js';
+import { GooglePlayError, ValidationError } from '../core/errors.js';
+import { commands } from './commands.js';
+import type { CliApi, CliCommand, CliValues } from './commands.js';
+
+export interface CliIo {
+  out: (text: string) => void;
+  err: (text: string) => void;
+}
+
+const BIN_NAME = 'google-play-scraper';
+
+const packageJsonSchema = z.object({ version: z.string() });
+
+const PACKAGE_JSON_CANDIDATES = ['../package.json', '../../package.json'];
+
+async function readVersion(): Promise<string> {
+  for (const candidate of PACKAGE_JSON_CANDIDATES) {
+    let raw: string;
+    try {
+      raw = await readFile(new URL(candidate, import.meta.url), 'utf8');
+    } catch {
+      continue;
+    }
+    return packageJsonSchema.parse(JSON.parse(raw)).version;
+  }
+  throw new GooglePlayError('unable to locate package.json for --version');
+}
+
+function renderHelp(): string {
+  const width = Math.max(...commands.map((command) => command.name.length));
+  const lines = [
+    `Usage: ${BIN_NAME} <command> [argument] [flags]`,
+    '',
+    'Commands:',
+    ...commands.map((command) => `  ${command.name.padEnd(width)}  ${command.summary}`),
+    '',
+    `Run "${BIN_NAME} <command> --help" for the flags of one command.`,
+    'Base flags for every command: --lang <code>, --country <code>, --throttle <requestsPerSecond>',
+    'Global flags: --help, --version',
+  ];
+  return lines.join('\n');
+}
+
+function commandUsage(command: CliCommand): string {
+  return `Usage: ${BIN_NAME} ${command.usage}`;
+}
+
+function usageFailure(io: CliIo, message: string, command: CliCommand | undefined): 2 {
+  io.err(`${BIN_NAME}: ${message}\n`);
+  io.err(`${command === undefined ? renderHelp() : commandUsage(command)}\n`);
+  return 2;
+}
+
+function isParseArgsError(error: unknown): error is TypeError & { code: string } {
+  return (
+    error instanceof TypeError &&
+    'code' in error &&
+    typeof error.code === 'string' &&
+    error.code.startsWith('ERR_PARSE_ARGS')
+  );
+}
+
+export async function runCli(
+  argv: readonly string[],
+  io: CliIo,
+  api: CliApi = gplay,
+): Promise<0 | 1 | 2> {
+  const [first, ...rest] = argv;
+  if (first === undefined) {
+    io.err(`${renderHelp()}\n`);
+    return 2;
+  }
+  if (first === '--help' || first === '-h') {
+    io.out(`${renderHelp()}\n`);
+    return 0;
+  }
+  if (first === '--version') {
+    io.out(`${await readVersion()}\n`);
+    return 0;
+  }
+  const command = commands.find((entry) => entry.name === first);
+  if (command === undefined) {
+    return usageFailure(io, `unknown command "${first}"`, undefined);
+  }
+  let positionals: string[];
+  let values: CliValues;
+  try {
+    const parsed = parseArgs({
+      args: rest,
+      options: { ...command.options, help: { type: 'boolean' } },
+      strict: true,
+      allowPositionals: true,
+    });
+    positionals = parsed.positionals;
+    values = parsed.values;
+  } catch (error) {
+    if (isParseArgsError(error)) {
+      return usageFailure(io, error.message, command);
+    }
+    throw error;
+  }
+  if (values.help === true) {
+    io.out(`${commandUsage(command)}\n`);
+    return 0;
+  }
+  const positional = positionals[0];
+  if (command.requiresPositional && positional === undefined) {
+    return usageFailure(io, `${command.name}: missing required argument`, command);
+  }
+  try {
+    const result = await command.execute(positional ?? '', values, api);
+    io.out(`${JSON.stringify(result, null, 2)}\n`);
+    return 0;
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return usageFailure(io, error.message, command);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    io.err(`${BIN_NAME}: ${message}\n`);
+    return 1;
+  }
+}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -111,6 +111,11 @@ export async function runCli(
   if (command.requiresPositional && positional === undefined) {
     return usageFailure(io, `${command.name}: missing required argument`, command);
   }
+  const expectedPositionals = command.requiresPositional ? 1 : 0;
+  if (positionals.length > expectedPositionals) {
+    const unexpected = positionals[expectedPositionals] ?? '';
+    return usageFailure(io, `${command.name}: unexpected argument "${unexpected}"`, command);
+  }
   try {
     const result = await command.execute(positional ?? '', values, api);
     io.out(`${JSON.stringify(result, null, 2)}\n`);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -91,7 +91,7 @@ export async function runCli(
   try {
     const parsed = parseArgs({
       args: rest,
-      options: { ...command.options, help: { type: 'boolean' } },
+      options: { ...command.options, help: { type: 'boolean', short: 'h' } },
       strict: true,
       allowPositionals: true,
     });

--- a/src/cli/cliVersion.test.ts
+++ b/src/cli/cliVersion.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runCli } from './cli.js';
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(() => Promise.reject(new Error('ENOENT'))),
+}));
+
+describe('runCli --version without a readable package.json', () => {
+  it('returns 1 with a clean message instead of rejecting', async () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = await runCli(['--version'], {
+      out: (text) => {
+        out.push(text);
+      },
+      err: (text) => {
+        err.push(text);
+      },
+    });
+    expect(code).toBe(1);
+    expect(out).toEqual([]);
+    expect(err.join('')).toContain('unable to locate package.json');
+  });
+});

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import { sort } from '../constants.js';
+import { ValidationError } from '../core/errors.js';
+import { commands } from './commands.js';
+import type { CliApi, CliCommand, CliValues } from './commands.js';
+
+interface RecordedCall {
+  method: string;
+  options: unknown;
+}
+
+const API_METHODS = [
+  'app',
+  'apps',
+  'search',
+  'suggest',
+  'list',
+  'developer',
+  'similar',
+  'reviews',
+  'permissions',
+  'datasafety',
+  'categories',
+  'availability',
+] as const;
+
+function createStubApi(result: unknown = { stub: true }): { api: CliApi; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const api = Object.fromEntries(
+    API_METHODS.map((method) => [
+      method,
+      (options: unknown) => {
+        calls.push({ method, options });
+        return Promise.resolve(result);
+      },
+    ]),
+  ) as unknown as CliApi;
+  return { api, calls };
+}
+
+function getCommand(name: string): CliCommand {
+  const command = commands.find((entry) => entry.name === name);
+  if (command === undefined) {
+    throw new Error(`missing command ${name}`);
+  }
+  return command;
+}
+
+async function run(
+  name: string,
+  positional: string,
+  values: CliValues = {},
+): Promise<RecordedCall> {
+  const { api, calls } = createStubApi();
+  await getCommand(name).execute(positional, values, api);
+  const call = calls[0];
+  if (call === undefined) {
+    throw new Error(`command ${name} did not call the api`);
+  }
+  return call;
+}
+
+describe('command dispatch', () => {
+  const cases: { name: string; positional: string; values?: CliValues; expected: object }[] = [
+    { name: 'app', positional: 'com.example', expected: { appId: 'com.example' } },
+    {
+      name: 'apps',
+      positional: 'com.a, com.b,com.c',
+      expected: { appIds: ['com.a', 'com.b', 'com.c'] },
+    },
+    { name: 'search', positional: 'panda', expected: { term: 'panda' } },
+    { name: 'suggest', positional: 'panda', expected: { term: 'panda' } },
+    { name: 'list', positional: '', expected: {} },
+    { name: 'developer', positional: 'DevCo', expected: { devId: 'DevCo' } },
+    { name: 'similar', positional: 'com.example', expected: { appId: 'com.example' } },
+    { name: 'reviews', positional: 'com.example', expected: { appId: 'com.example' } },
+    { name: 'permissions', positional: 'com.example', expected: { appId: 'com.example' } },
+    { name: 'datasafety', positional: 'com.example', expected: { appId: 'com.example' } },
+    { name: 'categories', positional: '', expected: {} },
+    {
+      name: 'availability',
+      positional: 'com.example',
+      values: { countries: 'us' },
+      expected: { appId: 'com.example', countries: ['us'] },
+    },
+  ];
+
+  it('covers every command in the table', () => {
+    expect(cases.map((entry) => entry.name).sort()).toEqual(
+      commands.map((command) => command.name).sort(),
+    );
+  });
+
+  it.each(cases)('$name calls exactly its api function', async ({ name, positional, values }) => {
+    const call = await run(name, positional, values ?? {});
+    expect(call.method).toBe(name);
+  });
+
+  it.each(cases)(
+    '$name maps the positional into the right field',
+    async ({ name, positional, values, expected }) => {
+      const call = await run(name, positional, values ?? {});
+      expect(call.options).toMatchObject(expected);
+    },
+  );
+
+  it.each(commands.map((command) => ({ name: command.name })))(
+    '$name forwards the base trio',
+    async ({ name }) => {
+      const values: CliValues = { lang: 'de', country: 'de', throttle: '2' };
+      if (name === 'availability') {
+        values.countries = 'us';
+      }
+      const call = await run(name, 'com.example', values);
+      expect(call.options).toMatchObject({ lang: 'de', country: 'de', throttle: 2 });
+    },
+  );
+});
+
+describe('flag mapping', () => {
+  it('maps --full-detail to fullDetail true', async () => {
+    const call = await run('search', 'panda', { 'full-detail': true });
+    expect(call.options).toMatchObject({ fullDetail: true });
+  });
+
+  it('maps a missing --full-detail to fullDetail false', async () => {
+    const call = await run('search', 'panda');
+    expect(call.options).toMatchObject({ fullDetail: false });
+  });
+
+  it('maps --token to nextPaginationToken', async () => {
+    const call = await run('reviews', 'com.example', { token: 'abc' });
+    expect(call.options).toMatchObject({ nextPaginationToken: 'abc' });
+  });
+
+  it('coerces --num to a number', async () => {
+    const call = await run('search', 'panda', { num: '5' });
+    expect(call.options).toMatchObject({ num: 5 });
+  });
+
+  it('coerces a garbage --num to NaN for the feature schema to reject', async () => {
+    const call = await run('search', 'panda', { num: 'abc' });
+    expect(call.options).toMatchObject({ num: Number.NaN });
+  });
+
+  it('coerces --concurrency to a number', async () => {
+    const call = await run('apps', 'com.a', { concurrency: '3' });
+    expect(call.options).toMatchObject({ concurrency: 3 });
+  });
+});
+
+describe('sort mapping', () => {
+  it.each([
+    { name: 'newest', value: sort.NEWEST },
+    { name: 'rating', value: sort.RATING },
+    { name: 'helpfulness', value: sort.HELPFULNESS },
+  ])('maps --sort $name to the sort constant', async ({ name, value }) => {
+    const call = await run('reviews', 'com.example', { sort: name });
+    expect(call.options).toMatchObject({ sort: value });
+  });
+
+  it('rejects an unknown sort name listing the valid choices', () => {
+    const { api } = createStubApi();
+    expect(() => getCommand('reviews').execute('com.example', { sort: 'banana' }, api)).toThrow(
+      'sort must be one of newest, rating, helpfulness',
+    );
+  });
+});
+
+describe('list choices', () => {
+  it('accepts known collection, category and age names', async () => {
+    const call = await run('list', '', {
+      collection: 'TOP_PAID',
+      category: 'GAME_ACTION',
+      age: 'AGE_RANGE1',
+    });
+    expect(call.options).toMatchObject({
+      collection: 'TOP_PAID',
+      category: 'GAME_ACTION',
+      age: 'AGE_RANGE1',
+    });
+  });
+
+  it('rejects an unknown collection listing the valid choices', () => {
+    const { api } = createStubApi();
+    const attempt = (): Promise<unknown> =>
+      getCommand('list').execute('', { collection: 'TOP_BANANA' }, api);
+    expect(attempt).toThrow(ValidationError);
+    expect(attempt).toThrow('collection must be one of TOP_FREE, TOP_PAID, GROSSING');
+  });
+
+  it('rejects an unknown price listing the valid choices', () => {
+    const { api } = createStubApi();
+    expect(() => getCommand('search').execute('panda', { price: 'cheap' }, api)).toThrow(
+      'price must be one of all, free, paid',
+    );
+  });
+});
+
+describe('availability countries', () => {
+  it('splits, trims and lowercases the country list', async () => {
+    const call = await run('availability', 'com.example', { countries: 'us, PL ,de' });
+    expect(call.options).toMatchObject({ countries: ['us', 'pl', 'de'] });
+  });
+
+  it('rejects a missing --countries', () => {
+    const { api } = createStubApi();
+    expect(() => getCommand('availability').execute('com.example', {}, api)).toThrow(
+      ValidationError,
+    );
+  });
+});

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -149,6 +149,51 @@ describe('flag mapping', () => {
   });
 });
 
+describe('comma list handling', () => {
+  it('apps drops empty segments and trims whitespace', async () => {
+    const call = await run('apps', ' com.a ,, com.b ,');
+    expect(call.options).toMatchObject({ appIds: ['com.a', 'com.b'] });
+  });
+
+  it('availability drops empty segments before lowercasing', async () => {
+    const call = await run('availability', 'com.example', { countries: 'us,, PL ,' });
+    expect(call.options).toMatchObject({ countries: ['us', 'pl'] });
+  });
+
+  it('apps forwards an empty list from a blank positional for the schema to reject', async () => {
+    const call = await run('apps', '');
+    expect(call.options).toMatchObject({ appIds: [] });
+  });
+});
+
+describe('absent flags', () => {
+  it('leaves unset numeric flags undefined so feature defaults apply', async () => {
+    const call = await run('search', 'panda');
+    const options = call.options as { num?: number; throttle?: number };
+    expect(options.num).toBeUndefined();
+    expect(options.throttle).toBeUndefined();
+  });
+
+  it('leaves unset base flags undefined so feature defaults apply', async () => {
+    const call = await run('app', 'com.example');
+    const options = call.options as { lang?: string; country?: string };
+    expect(options.lang).toBeUndefined();
+    expect(options.country).toBeUndefined();
+  });
+
+  it('leaves an unset --sort undefined so the feature default applies', async () => {
+    const call = await run('reviews', 'com.example');
+    const options = call.options as { sort?: number };
+    expect(options.sort).toBeUndefined();
+  });
+
+  it('leaves an unset --token undefined', async () => {
+    const call = await run('reviews', 'com.example');
+    const options = call.options as { nextPaginationToken?: string };
+    expect(options.nextPaginationToken).toBeUndefined();
+  });
+});
+
 describe('sort mapping', () => {
   it.each([
     { name: 'newest', value: sort.NEWEST },
@@ -157,6 +202,11 @@ describe('sort mapping', () => {
   ])('maps --sort $name to the sort constant', async ({ name, value }) => {
     const call = await run('reviews', 'com.example', { sort: name });
     expect(call.options).toMatchObject({ sort: value });
+  });
+
+  it('matches sort names case-insensitively', async () => {
+    const call = await run('reviews', 'com.example', { sort: 'RATING' });
+    expect(call.options).toMatchObject({ sort: sort.RATING });
   });
 
   it('rejects an unknown sort name listing the valid choices', () => {
@@ -193,6 +243,18 @@ describe('list choices', () => {
     const { api } = createStubApi();
     expect(() => getCommand('search').execute('panda', { price: 'cheap' }, api)).toThrow(
       'price must be one of all, free, paid',
+    );
+  });
+
+  it.each(['all', 'free', 'paid'] as const)('passes price %s through unchanged', async (price) => {
+    const call = await run('search', 'panda', { price });
+    expect(call.options).toMatchObject({ price });
+  });
+
+  it('rejects an unknown age listing the valid choices', () => {
+    const { api } = createStubApi();
+    expect(() => getCommand('list').execute('', { age: 'AGE_RANGE9' }, api)).toThrow(
+      'age must be one of AGE_RANGE1, AGE_RANGE2, AGE_RANGE3',
     );
   });
 });

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,295 @@
+import type gplay from '../index.js';
+import { age, category, collection, sort } from '../constants.js';
+import type { Sort } from '../constants.js';
+import { ValidationError } from '../core/errors.js';
+import type { SearchOptions } from '../features/search/search.js';
+
+export type CliApi = Pick<
+  typeof gplay,
+  | 'app'
+  | 'apps'
+  | 'search'
+  | 'suggest'
+  | 'list'
+  | 'developer'
+  | 'similar'
+  | 'reviews'
+  | 'permissions'
+  | 'datasafety'
+  | 'categories'
+  | 'availability'
+>;
+
+export type CliValues = Record<string, string | boolean | (string | boolean)[] | undefined>;
+
+export type CliFlagConfigs = Record<string, { type: 'string' | 'boolean' }>;
+
+export interface CliCommand {
+  name: string;
+  summary: string;
+  usage: string;
+  requiresPositional: boolean;
+  options: CliFlagConfigs;
+  execute: (positional: string, values: CliValues, api: CliApi) => Promise<unknown>;
+}
+
+const baseFlags: CliFlagConfigs = {
+  lang: { type: 'string' },
+  country: { type: 'string' },
+  throttle: { type: 'string' },
+};
+
+const BASE_FLAGS_USAGE = '[--lang <code>] [--country <code>] [--throttle <requestsPerSecond>]';
+
+function stringValue(values: CliValues, key: string): string | undefined {
+  const value = values[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberValue(values: CliValues, key: string): number | undefined {
+  const value = stringValue(values, key);
+  return value === undefined ? undefined : Number(value);
+}
+
+function booleanValue(values: CliValues, key: string): boolean {
+  return values[key] === true;
+}
+
+function baseOptions(values: CliValues): {
+  lang: string | undefined;
+  country: string | undefined;
+  throttle: number | undefined;
+} {
+  return {
+    lang: stringValue(values, 'lang'),
+    country: stringValue(values, 'country'),
+    throttle: numberValue(values, 'throttle'),
+  };
+}
+
+function splitCommaList(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function enumValue<T extends string>(
+  values: CliValues,
+  key: string,
+  choices: Readonly<Record<string, T>>,
+  context: string,
+): T | undefined {
+  const value = stringValue(values, key);
+  if (value === undefined) {
+    return undefined;
+  }
+  for (const choice of Object.values(choices)) {
+    if (choice === value) {
+      return choice;
+    }
+  }
+  throw new ValidationError(
+    `${context}: ${key} must be one of ${Object.values(choices).join(', ')}`,
+  );
+}
+
+function sortValue(values: CliValues): Sort | undefined {
+  const name = stringValue(values, 'sort');
+  if (name === undefined) {
+    return undefined;
+  }
+  for (const [key, value] of Object.entries(sort)) {
+    if (key.toLowerCase() === name.toLowerCase()) {
+      return value;
+    }
+  }
+  const choices = Object.keys(sort)
+    .map((key) => key.toLowerCase())
+    .join(', ');
+  throw new ValidationError(`reviews: sort must be one of ${choices}`);
+}
+
+function priceValue(values: CliValues): SearchOptions['price'] {
+  const value = stringValue(values, 'price');
+  if (value === undefined || value === 'all' || value === 'free' || value === 'paid') {
+    return value;
+  }
+  throw new ValidationError('search: price must be one of all, free, paid');
+}
+
+function countriesValue(values: CliValues): string[] {
+  const value = stringValue(values, 'countries');
+  if (value === undefined) {
+    throw new ValidationError('availability: --countries is required');
+  }
+  return splitCommaList(value).map((country) => country.toLowerCase());
+}
+
+export const commands: readonly CliCommand[] = [
+  {
+    name: 'app',
+    summary: 'full detail of a single application',
+    usage: `app <appId> ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: { ...baseFlags },
+    execute: (positional, values, api) => api.app({ appId: positional, ...baseOptions(values) }),
+  },
+  {
+    name: 'apps',
+    summary: 'full details for many applications at once',
+    usage: `apps <appId,appId,...> [--concurrency <n>] ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: { ...baseFlags, concurrency: { type: 'string' } },
+    execute: (positional, values, api) =>
+      api.apps({
+        appIds: splitCommaList(positional),
+        concurrency: numberValue(values, 'concurrency'),
+        ...baseOptions(values),
+      }),
+  },
+  {
+    name: 'search',
+    summary: 'apps matching a search term',
+    usage: `search <term> [--num <n>] [--price all|free|paid] [--full-detail] ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: {
+      ...baseFlags,
+      num: { type: 'string' },
+      price: { type: 'string' },
+      'full-detail': { type: 'boolean' },
+    },
+    execute: (positional, values, api) =>
+      api.search({
+        term: positional,
+        num: numberValue(values, 'num'),
+        price: priceValue(values),
+        fullDetail: booleanValue(values, 'full-detail'),
+        ...baseOptions(values),
+      }),
+  },
+  {
+    name: 'suggest',
+    summary: 'search term autocompletions',
+    usage: `suggest <term> ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: { ...baseFlags },
+    execute: (positional, values, api) => api.suggest({ term: positional, ...baseOptions(values) }),
+  },
+  {
+    name: 'list',
+    summary: 'a ranked collection of apps',
+    usage: `list [--collection <name>] [--category <name>] [--age <name>] [--num <n>] [--full-detail] ${BASE_FLAGS_USAGE}`,
+    requiresPositional: false,
+    options: {
+      ...baseFlags,
+      collection: { type: 'string' },
+      category: { type: 'string' },
+      age: { type: 'string' },
+      num: { type: 'string' },
+      'full-detail': { type: 'boolean' },
+    },
+    execute: (_positional, values, api) =>
+      api.list({
+        collection: enumValue(values, 'collection', collection, 'list'),
+        category: enumValue(values, 'category', category, 'list'),
+        age: enumValue(values, 'age', age, 'list'),
+        num: numberValue(values, 'num'),
+        fullDetail: booleanValue(values, 'full-detail'),
+        ...baseOptions(values),
+      }),
+  },
+  {
+    name: 'developer',
+    summary: 'other apps by the same developer',
+    usage: `developer <devId> [--num <n>] [--full-detail] ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: { ...baseFlags, num: { type: 'string' }, 'full-detail': { type: 'boolean' } },
+    execute: (positional, values, api) =>
+      api.developer({
+        devId: positional,
+        num: numberValue(values, 'num'),
+        fullDetail: booleanValue(values, 'full-detail'),
+        ...baseOptions(values),
+      }),
+  },
+  {
+    name: 'similar',
+    summary: 'apps related to a given app',
+    usage: `similar <appId> [--full-detail] ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: { ...baseFlags, 'full-detail': { type: 'boolean' } },
+    execute: (positional, values, api) =>
+      api.similar({
+        appId: positional,
+        fullDetail: booleanValue(values, 'full-detail'),
+        ...baseOptions(values),
+      }),
+  },
+  {
+    name: 'reviews',
+    summary: 'user reviews for an app',
+    usage: `reviews <appId> [--num <n>] [--sort newest|rating|helpfulness] [--paginate] [--token <token>] ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: {
+      ...baseFlags,
+      num: { type: 'string' },
+      sort: { type: 'string' },
+      paginate: { type: 'boolean' },
+      token: { type: 'string' },
+    },
+    execute: (positional, values, api) =>
+      api.reviews({
+        appId: positional,
+        num: numberValue(values, 'num'),
+        sort: sortValue(values),
+        paginate: booleanValue(values, 'paginate'),
+        nextPaginationToken: stringValue(values, 'token'),
+        ...baseOptions(values),
+      }),
+  },
+  {
+    name: 'permissions',
+    summary: 'permissions an app requests',
+    usage: `permissions <appId> [--short] ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: { ...baseFlags, short: { type: 'boolean' } },
+    execute: (positional, values, api) =>
+      api.permissions({
+        appId: positional,
+        short: booleanValue(values, 'short'),
+        ...baseOptions(values),
+      }),
+  },
+  {
+    name: 'datasafety',
+    summary: 'the data safety section of an app',
+    usage: `datasafety <appId> ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: { ...baseFlags },
+    execute: (positional, values, api) =>
+      api.datasafety({ appId: positional, ...baseOptions(values) }),
+  },
+  {
+    name: 'categories',
+    summary: 'the Google Play category taxonomy',
+    usage: `categories ${BASE_FLAGS_USAGE}`,
+    requiresPositional: false,
+    options: { ...baseFlags },
+    execute: (_positional, values, api) => api.categories({ ...baseOptions(values) }),
+  },
+  {
+    name: 'availability',
+    summary: 'per-country availability of an app',
+    usage: `availability <appId> --countries <cc,cc,...> [--concurrency <n>] ${BASE_FLAGS_USAGE}`,
+    requiresPositional: true,
+    options: { ...baseFlags, countries: { type: 'string' }, concurrency: { type: 'string' } },
+    execute: (positional, values, api) =>
+      api.availability({
+        appId: positional,
+        countries: countriesValue(values),
+        concurrency: numberValue(values, 'concurrency'),
+        ...baseOptions(values),
+      }),
+  },
+];

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { runCli } from './cli.js';
+
+process.exitCode = await runCli(process.argv.slice(2), {
+  out: (text) => {
+    process.stdout.write(text);
+  },
+  err: (text) => {
+    process.stderr.write(text);
+  },
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,15 +1,27 @@
 import { defineConfig } from 'tsdown';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
-  outExtensions: ({ format }) => ({
-    js: format === 'es' ? '.js' : '.cjs',
-    dts: format === 'es' ? '.d.ts' : '.d.cts',
-  }),
-  dts: true,
-  sourcemap: true,
-  clean: true,
-  platform: 'node',
-  target: 'node22',
-});
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    outExtensions: ({ format }) => ({
+      js: format === 'es' ? '.js' : '.cjs',
+      dts: format === 'es' ? '.d.ts' : '.d.cts',
+    }),
+    dts: true,
+    sourcemap: true,
+    clean: true,
+    platform: 'node',
+    target: 'node22',
+  },
+  {
+    entry: { cli: 'src/cli/main.ts' },
+    format: ['esm'],
+    outExtensions: () => ({ js: '.js' }),
+    dts: false,
+    sourcemap: true,
+    clean: false,
+    platform: 'node',
+    target: 'node22',
+  },
+]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json-summary'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/index.ts'],
+      exclude: ['src/**/*.test.ts', 'src/index.ts', 'src/cli/main.ts'],
       thresholds: {
         statements: 99,
         branches: 96,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `google-play-scraper` command-line interface with multiple subcommands, JSON output, localized querying, pagination, and command/global help plus `--version`.
  * Updated README with a new CLI section, example commands (including piping to `jq`), supported flags/positional args, and defined exit codes.
* **Tests**
  * Added end-to-end CLI coverage for JSON shape, per-command behaviors, validation errors, and process-level exit code/stderr contracts.
  * Added unit tests for command dispatch, flag/option mapping, and input validation.
* **Chores**
  * Exposed the CLI via `package.json`, added a dedicated build for the CLI entry, and adjusted test coverage exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->