### PR TITLE
docs(readme): document versioning contract and provenance verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This is a modern TypeScript rewrite of the popular but unmaintained [`google-pla
 - [Throttling and requestOptions](#throttling-and-requestoptions)
 - [Resilience](#resilience)
 - [Monitoring drift](#monitoring-drift)
+- [Versioning and API stability](#versioning-and-api-stability)
 - [Migrating from google-play-scraper](#migrating-from-google-play-scraper)
 - [FAQ](#faq)
 - [Related projects](#related-projects)
@@ -940,6 +941,26 @@ Two boundaries to know:
 - `reviews` pagination never degrades. A parse failure there propagates as a `ParseError`, so review reads fail loudly instead of silently shrinking.
 
 With `memoized()`, `onDegradation` and the lifecycle hooks `onRequest`, `onResponse`, and `onRetry` participate in the cache key by identity like any function option, so pass stable function references rather than inline closures to keep cache hits.
+
+## Versioning and API stability
+
+This package follows [Semantic Versioning](https://semver.org). For a scraper the contract needs one clarification: semver covers the code surface this library controls, not the data Google serves.
+
+| Change                                                            | Release |
+| ----------------------------------------------------------------- | ------- |
+| Removing or renaming an exported function, option, or constant    | major   |
+| Removing a field from a result schema, or changing its type       | major   |
+| Raising the Node.js support floor or dropping a module format     | major   |
+| Adding a new method, option, or optional result field             | minor   |
+| Restoring extraction of a field after a Google Play layout change | patch   |
+
+What semver cannot cover is the content behind those shapes. Google Play changes its markup a few times a year, and a field can start coming back `undefined`, empty, or degraded without any release of this package. The policy for that case:
+
+- The daily live test suite fails and an issue is filed automatically, usually before user reports arrive.
+- When extraction can be restored, the fix ships as a patch.
+- When Google removes the underlying data permanently, the field stays in the schema as a documented degraded surface first (see [categories](#categories) for the worked example) and is only removed in the next major.
+
+To watch for drift in your own production use, wire up [`onDegradation`](#monitoring-drift) and treat [`SpecError`](#error-handling) as a layout-change signal rather than an application bug.
 
 ## Migrating from google-play-scraper
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ npm install @mradex77/google-play-scraper
 
 Requires Node.js 22.12 or newer.
 
+Every release is published from GitHub Actions with [npm provenance](https://docs.npmjs.com/generating-provenance-statements), so the package on npm is cryptographically linked to the exact commit and workflow that built it. Verify your installed tree with:
+
+```sh
+npm audit signatures
+```
+
 ## CLI
 
 Every method with a JSON-friendly surface is also available from the command line, no install required:


### PR DESCRIPTION
## What

Documents the trust half of the release story in `README.md`. The code half (npm provenance publishing and the Node 22/24 CI matrix) already shipped; this PR does not touch any workflow.

- New `## Versioning and API stability` section between `## Monitoring drift` and `## Migrating from google-play-scraper`, with a matching table-of-contents entry. It defines exactly what semver covers for a scraper (code surface, not the data Google serves), tabulates major/minor/patch triggers, and states the degraded-surface policy, linking to `categories`, `onDegradation`, and `SpecError`.
- Provenance note appended to `## Installation` explaining that releases are published with npm provenance and how to verify with `npm audit signatures`.

## Verification of already-shipped items

- `release.yml` still publishes with `npm publish --provenance --access public` and grants `id-token: write`.
- `ci.yml` still runs the verify job on `node: [22, 24]`.

Neither needed a fix, so no `ci:` commit was required.

## Notes

- No code changed; docs only. `pnpm lint`, `pnpm typecheck`, `pnpm test:coverage`, `pnpm build`, and `pnpm format:check` all pass.
- `dist.attestations` cannot be verified from this branch. Post-release follow-up: run `npm view @mradex77/google-play-scraper --json | jq .dist.attestations` after the next release to confirm a provenance URL is present.

## Commits

1. `docs(readme): define the semver contract for scraped data`
2. `docs(readme): document npm provenance verification`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for verifying package provenance during installation.
  * Documented Semantic Versioning rules for the library.
  * Clarified how versioning applies to served data and extraction changes.
  * Updated the table of contents to include the new versioning and API stability section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->