### PR TITLE
refactor(api)!: rename datasafety to dataSafety

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ npx @mradex77/google-play-scraper availability com.adex77.WhereAmI --countries u
 | `similar <appId>`      | app id                  | `--full-detail`                                                 |
 | `reviews <appId>`      | app id                  | `--num`, `--sort`, `--paginate`, `--token`                      |
 | `permissions <appId>`  | app id                  | `--short`                                                       |
-| `datasafety <appId>`   | app id                  |                                                                 |
+| `data-safety <appId>`  | app id                  |                                                                 |
 | `categories`           |                         |                                                                 |
 | `availability <appId>` | app id                  | `--countries` (comma-separated, required), `--concurrency`      |
 
@@ -184,7 +184,7 @@ Every method from the [reference below](#methods) is available on the client, al
 - [similar](#similar): apps related to a given app
 - [reviews](#reviews): user reviews for an app
 - [permissions](#permissions): permissions an app requests
-- [datasafety](#datasafety): the data safety section of an app
+- [dataSafety](#datasafety): the data safety section of an app
 - [categories](#categories): the Google Play category taxonomy
 - [memoized](#memoized): a client that caches identical calls
 
@@ -566,7 +566,7 @@ Returns `AppPermission[]` (or `string[]` when `short` is `true`):
 
 The `type` is `permission.COMMON` (`0`) or `permission.OTHER` (`1`).
 
-### datasafety
+### dataSafety
 
 Returns the data safety section of an app.
 
@@ -575,9 +575,9 @@ Returns the data safety section of an app.
 | `appId` | `string` | required | The Google Play id of the app. |
 
 ```typescript
-import { datasafety } from '@mradex77/google-play-scraper';
+import { dataSafety } from '@mradex77/google-play-scraper';
 
-const safety = await datasafety({ appId: 'com.google.android.apps.translate' });
+const safety = await dataSafety({ appId: 'com.google.android.apps.translate' });
 ```
 
 Returns `DataSafety`. Trimmed:
@@ -778,7 +778,7 @@ An unknown `appId` or `devId` does not fail the same way everywhere, because Goo
 | Behavior for a missing app        | Methods                                                                                                                                                        |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Throws `NotFoundError`            | `app`, `apps` (per entry, as a rejected `PromiseSettledResult`), `similar`, `developer`                                                                        |
-| Resolves with a typed empty value | `search` and `suggest` (`[]`), `reviews` (`{ data: [], nextPaginationToken: null }`), `permissions` (`[]`), `datasafety` (empty arrays, no `privacyPolicyUrl`) |
+| Resolves with a typed empty value | `search` and `suggest` (`[]`), `reviews` (`{ data: [], nextPaginationToken: null }`), `permissions` (`[]`), `dataSafety` (empty arrays, no `privacyPolicyUrl`) |
 | Maps the throw to a status        | `availability` reports `unavailable`                                                                                                                           |
 
 ## Throttling and requestOptions
@@ -890,7 +890,7 @@ const details = await app({
 });
 ```
 
-Routes accept any `typeof fetch`, so the same helper also works for per-country rate limiting, logging or fixtures in tests. Omit `fallback` to send unmatched countries through a direct connection. The only request without a `gl` parameter is the `datasafety` page fetch, which always uses the fallback route.
+Routes accept any `typeof fetch`, so the same helper also works for per-country rate limiting, logging or fixtures in tests. Omit `fallback` to send unmatched countries through a direct connection. The only request without a `gl` parameter is the `dataSafety` page fetch, which always uses the fallback route.
 
 Pass an `AbortSignal` to cancel long running calls, such as a `reviews` fetch that walks many pages. An aborted call rejects with the signal's reason and is never retried:
 

--- a/e2e/cli.e2e.test.ts
+++ b/e2e/cli.e2e.test.ts
@@ -199,8 +199,8 @@ liveDescribe('cli commands against live google play', () => {
     expect(JSON.parse(stdout)).toEqual([]);
   });
 
-  it('datasafety reports collected data and a privacy policy url', async () => {
-    const parsed = await runCliJson(['datasafety', TRANSLATE_ID]);
+  it('data-safety reports collected data and a privacy policy url', async () => {
+    const parsed = await runCliJson(['data-safety', TRANSLATE_ID]);
     const report = parsed as {
       collectedData: { data: string }[];
       securityPractices: { practice: string }[];
@@ -211,8 +211,8 @@ liveDescribe('cli commands against live google play', () => {
     expect(report.privacyPolicyUrl?.startsWith('http')).toBe(true);
   });
 
-  it('datasafety prints an empty report for a missing app and exits 0', async () => {
-    const parsed = await runCliJson(['datasafety', MISSING_ID]);
+  it('data-safety prints an empty report for a missing app and exits 0', async () => {
+    const parsed = await runCliJson(['data-safety', MISSING_ID]);
     const report = parsed as Record<string, unknown>;
     expect(report.sharedData).toEqual([]);
     expect(report.collectedData).toEqual([]);
@@ -270,7 +270,7 @@ describe('cli process contract', () => {
     const { exitCode, stdout, stderr } = await runCliProcess(['--help']);
     expect(exitCode).toBe(0);
     expect(stderr).toBe('');
-    for (const name of ['app', 'search', 'reviews', 'availability', 'datasafety']) {
+    for (const name of ['app', 'search', 'reviews', 'availability', 'data-safety']) {
       expect(stdout).toContain(name);
     }
   });

--- a/e2e/datasafety.e2e.test.ts
+++ b/e2e/datasafety.e2e.test.ts
@@ -5,7 +5,7 @@ const TRANSLATE = 'com.google.android.apps.translate';
 
 liveDescribe('datasafety live contract', () => {
   it('returns collected data, security practices, and a privacy policy url', async () => {
-    const result = await liveClient.datasafety({ appId: TRANSLATE });
+    const result = await liveClient.dataSafety({ appId: TRANSLATE });
 
     expect(result.collectedData.length).toBeGreaterThan(0);
     for (const entry of result.collectedData) {
@@ -23,7 +23,7 @@ liveDescribe('datasafety live contract', () => {
   });
 
   it('returns a typed safety report for the Where Am I geography game', async () => {
-    const result = await liveClient.datasafety({ appId: 'com.adex77.WhereAmI' });
+    const result = await liveClient.dataSafety({ appId: 'com.adex77.WhereAmI' });
 
     expect(Array.isArray(result.sharedData)).toBe(true);
     expect(Array.isArray(result.collectedData)).toBe(true);
@@ -37,7 +37,7 @@ liveDescribe('datasafety live contract', () => {
   });
 
   it('returns an empty report instead of throwing for a missing app', async () => {
-    const result = await liveClient.datasafety({
+    const result = await liveClient.dataSafety({
       appId: 'com.adex77.definitely.not.a.real.app',
     });
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,7 +34,7 @@ others still run.
 | `searchIterator()`                   | Streaming search matches page by page           |
 | `developerIterator()`                | Streaming a developer catalog page by page      |
 | `permissions()`                      | Permissions requested by an app                 |
-| `datasafety()`                       | The data safety section of an app               |
+| `dataSafety()`                       | The data safety section of an app               |
 | `createCountryFetch()`               | Routing requests to a per-country fetch         |
 | `errors`                             | The typed error hierarchy raised on failure     |
 | `memoized()`                         | A client that caches identical calls            |

--- a/examples/all-methods.ts
+++ b/examples/all-methods.ts
@@ -248,8 +248,8 @@ async function showPermissions(client: Client): Promise<void> {
 }
 
 async function showDataSafety(client: Client): Promise<void> {
-  heading('datasafety()', 'the data safety section of an app');
-  const safety = await client.datasafety({ appId: TEST_APP_ID });
+  heading('dataSafety()', 'the data safety section of an app');
+  const safety = await client.dataSafety({ appId: TEST_APP_ID });
   field('Shared data types', safety.sharedData.length);
   field('Collected data types', safety.collectedData.length);
   field('Security practices', safety.securityPractices.length);
@@ -352,7 +352,7 @@ async function main(): Promise<void> {
     await run('developerIterator()', () => showDeveloperIterator(client, details.developerId));
   }
   await run('permissions()', () => showPermissions(client));
-  await run('datasafety()', () => showDataSafety(client));
+  await run('dataSafety()', () => showDataSafety(client));
   await run('createCountryFetch()', showCountryFetch);
   await run('errors', showErrors);
   await run('memoized()', showMemoized);

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -38,7 +38,7 @@ const API_METHODS = [
   'similar',
   'reviews',
   'permissions',
-  'datasafety',
+  'dataSafety',
   'categories',
   'availability',
 ] as const;

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -19,7 +19,7 @@ const API_METHODS = [
   'similar',
   'reviews',
   'permissions',
-  'datasafety',
+  'dataSafety',
   'categories',
   'availability',
 ] as const;
@@ -61,7 +61,13 @@ async function run(
 }
 
 describe('command dispatch', () => {
-  const cases: { name: string; positional: string; values?: CliValues; expected: object }[] = [
+  const cases: {
+    name: string;
+    method?: string;
+    positional: string;
+    values?: CliValues;
+    expected: object;
+  }[] = [
     { name: 'app', positional: 'com.example', expected: { appId: 'com.example' } },
     {
       name: 'apps',
@@ -75,7 +81,12 @@ describe('command dispatch', () => {
     { name: 'similar', positional: 'com.example', expected: { appId: 'com.example' } },
     { name: 'reviews', positional: 'com.example', expected: { appId: 'com.example' } },
     { name: 'permissions', positional: 'com.example', expected: { appId: 'com.example' } },
-    { name: 'datasafety', positional: 'com.example', expected: { appId: 'com.example' } },
+    {
+      name: 'data-safety',
+      method: 'dataSafety',
+      positional: 'com.example',
+      expected: { appId: 'com.example' },
+    },
     { name: 'categories', positional: '', expected: {} },
     {
       name: 'availability',
@@ -91,10 +102,13 @@ describe('command dispatch', () => {
     );
   });
 
-  it.each(cases)('$name calls exactly its api function', async ({ name, positional, values }) => {
-    const call = await run(name, positional, values ?? {});
-    expect(call.method).toBe(name);
-  });
+  it.each(cases)(
+    '$name calls exactly its api function',
+    async ({ name, method, positional, values }) => {
+      const call = await run(name, positional, values ?? {});
+      expect(call.method).toBe(method ?? name);
+    },
+  );
 
   it.each(cases)(
     '$name maps the positional into the right field',

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -15,7 +15,7 @@ export type CliApi = Pick<
   | 'similar'
   | 'reviews'
   | 'permissions'
-  | 'datasafety'
+  | 'dataSafety'
   | 'categories'
   | 'availability'
 >;
@@ -262,13 +262,13 @@ export const commands: readonly CliCommand[] = [
       }),
   },
   {
-    name: 'datasafety',
+    name: 'data-safety',
     summary: 'the data safety section of an app',
-    usage: `datasafety <appId> ${BASE_FLAGS_USAGE}`,
+    usage: `data-safety <appId> ${BASE_FLAGS_USAGE}`,
     requiresPositional: true,
     options: { ...baseFlags },
     execute: (positional, values, api) =>
-      api.datasafety({ appId: positional, ...baseOptions(values) }),
+      api.dataSafety({ appId: positional, ...baseOptions(values) }),
   },
   {
     name: 'categories',

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -228,7 +228,7 @@ describe('createClient', () => {
       settle(client.developer({ devId: 'Adex77' })),
       settle(client.similar({ appId: TRANSLATE })),
       settle(client.permissions({ appId: TRANSLATE })),
-      settle(client.datasafety({ appId: TRANSLATE })),
+      settle(client.dataSafety({ appId: TRANSLATE })),
     ]);
 
     expect(urls).toHaveLength(6);

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,7 +15,7 @@ import {
   type AvailabilityOptions,
 } from './features/availability/availability.js';
 import { categories, type CategoriesOptions } from './features/categories/categories.js';
-import { createDatasafety, type DataSafetyOptions } from './features/datasafety/datasafety.js';
+import { createDataSafety, type DataSafetyOptions } from './features/datasafety/datasafety.js';
 import { createDeveloper, type DeveloperOptions } from './features/developer/developer.js';
 import { createList, type ListOptions } from './features/list/list.js';
 import { createPermissions, type PermissionsOptions } from './features/permissions/permissions.js';
@@ -109,7 +109,7 @@ export function createClient(options?: ClientOptions): GooglePlayClient & Google
   const boundSearchIterator = createSearchIterator(resolveClient);
   const boundDeveloperIterator = createDeveloperIterator(resolveClient);
   const boundPermissions = createPermissions(resolveClient);
-  const boundDatasafety = createDatasafety(resolveClient);
+  const boundDataSafety = createDataSafety(resolveClient);
 
   return {
     BASE_URL,
@@ -138,6 +138,6 @@ export function createClient(options?: ClientOptions): GooglePlayClient & Google
     developerIterator: (callOptions: DeveloperIteratorOptions) =>
       boundDeveloperIterator(mergeDefaults(callOptions)),
     permissions: (callOptions: PermissionsOptions) => boundPermissions(mergeDefaults(callOptions)),
-    datasafety: (callOptions: DataSafetyOptions) => boundDatasafety(mergeDefaults(callOptions)),
+    dataSafety: (callOptions: DataSafetyOptions) => boundDataSafety(mergeDefaults(callOptions)),
   };
 }

--- a/src/features/datasafety/datasafety.test.ts
+++ b/src/features/datasafety/datasafety.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { datasafety, type DataSafetyOptions } from './datasafety.js';
+import { dataSafety, type DataSafetyOptions } from './datasafety.js';
 import { ValidationError } from '../../core/errors.js';
 
 const TRANSLATE = 'com.google.android.apps.translate';
@@ -18,7 +18,7 @@ const fetchReturning =
 
 describe('datasafety fixture parsing', () => {
   it('extracts collected data entries with data, optional, and purpose fields', async () => {
-    const result = await datasafety({
+    const result = await dataSafety({
       appId: TRANSLATE,
       requestOptions: { fetchImpl: fetchReturning(fixture) },
     });
@@ -34,7 +34,7 @@ describe('datasafety fixture parsing', () => {
   });
 
   it('extracts security practices with nonempty practice strings', async () => {
-    const result = await datasafety({
+    const result = await dataSafety({
       appId: TRANSLATE,
       requestOptions: { fetchImpl: fetchReturning(fixture) },
     });
@@ -47,7 +47,7 @@ describe('datasafety fixture parsing', () => {
   });
 
   it('exposes a privacy policy url that parses', async () => {
-    const result = await datasafety({
+    const result = await dataSafety({
       appId: TRANSLATE,
       requestOptions: { fetchImpl: fetchReturning(fixture) },
     });
@@ -72,7 +72,7 @@ const wrapSafetyNode = (node: Record<string, unknown>): unknown[] => {
 
 describe('datasafety degraded pages', () => {
   it('returns empty defaults when the safety blocks are missing', async () => {
-    const result = await datasafety({
+    const result = await dataSafety({
       appId: TRANSLATE,
       requestOptions: { fetchImpl: fetchReturning(buildDataSafetyHtml([])) },
     });
@@ -100,7 +100,7 @@ describe('datasafety degraded pages', () => {
     ];
     const html = buildDataSafetyHtml(wrapSafetyNode({ '138': node138, '100': node100 }));
 
-    const result = await datasafety({
+    const result = await dataSafety({
       appId: TRANSLATE,
       requestOptions: { fetchImpl: fetchReturning(html) },
     });
@@ -118,6 +118,6 @@ describe('datasafety degraded pages', () => {
 
 describe('datasafety guards', () => {
   it('rejects a missing appId with a ValidationError', async () => {
-    await expect(datasafety({} as DataSafetyOptions)).rejects.toBeInstanceOf(ValidationError);
+    await expect(dataSafety({} as DataSafetyOptions)).rejects.toBeInstanceOf(ValidationError);
   });
 });

--- a/src/features/datasafety/datasafety.ts
+++ b/src/features/datasafety/datasafety.ts
@@ -7,7 +7,7 @@ import { extract } from '../../core/spec.js';
 import { dataSafetySchema, type DataSafety } from './schema.js';
 import { dataSafetySpecs } from './specs.js';
 
-const DATA_SAFETY_CONTEXT = 'datasafety';
+const DATA_SAFETY_CONTEXT = 'dataSafety';
 
 export const dataSafetyOptionsSchema = z.extend(baseOptionsSchema, {
   appId: z.string().check(z.minLength(1)),
@@ -17,8 +17,8 @@ export type DataSafetyOptions = z.input<typeof dataSafetyOptionsSchema>;
 
 const DATA_SAFETY_URL = `${BASE_URL}/store/apps/datasafety`;
 
-export function createDatasafety(resolveClient: ResolveClient = clientFromOptions) {
-  return async function datasafety(options: DataSafetyOptions): Promise<DataSafety> {
+export function createDataSafety(resolveClient: ResolveClient = clientFromOptions) {
+  return async function dataSafety(options: DataSafetyOptions): Promise<DataSafety> {
     const parsed = parseOptions(dataSafetyOptionsSchema, options, DATA_SAFETY_CONTEXT);
 
     const params = new URLSearchParams({ id: parsed.appId, hl: parsed.lang });
@@ -33,4 +33,4 @@ export function createDatasafety(resolveClient: ResolveClient = clientFromOption
   };
 }
 
-export const datasafety = createDatasafety();
+export const dataSafety = createDataSafety();

--- a/src/features/memoized/memoized.test.ts
+++ b/src/features/memoized/memoized.test.ts
@@ -213,7 +213,7 @@ describe('memoized', () => {
 
     expect(client.BASE_URL).toBe('https://play.google.com');
     expect(typeof client.reviews).toBe('function');
-    expect(typeof client.datasafety).toBe('function');
+    expect(typeof client.dataSafety).toBe('function');
     expect(typeof client.permissions).toBe('function');
     expect(typeof client.developer).toBe('function');
     expect(typeof client.similar).toBe('function');

--- a/src/features/memoized/memoized.ts
+++ b/src/features/memoized/memoized.ts
@@ -13,7 +13,7 @@ import { app } from '../app/app.js';
 import { createApps } from '../apps/apps.js';
 import { availability } from '../availability/availability.js';
 import { categories, type CategoriesOptions } from '../categories/categories.js';
-import { datasafety } from '../datasafety/datasafety.js';
+import { dataSafety } from '../datasafety/datasafety.js';
 import { createDeveloper } from '../developer/developer.js';
 import { createList } from '../list/list.js';
 import { permissions } from '../permissions/permissions.js';
@@ -129,6 +129,6 @@ export function memoized(options?: MemoizedOptions): GooglePlayClient {
     similar: memoize('similar', createSimilar(memoApp)),
     reviews: memoize('reviews', reviews),
     permissions: memoize('permissions', permissions),
-    datasafety: memoize('datasafety', datasafety),
+    dataSafety: memoize('dataSafety', dataSafety),
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export type { PermissionsOptions } from './features/permissions/permissions.js';
 export { permissionSchema } from './features/permissions/schema.js';
 export type { AppPermission } from './features/permissions/schema.js';
 
-export { datasafety, dataSafetyOptionsSchema } from './features/datasafety/datasafety.js';
+export { dataSafety, dataSafetyOptionsSchema } from './features/datasafety/datasafety.js';
 export type { DataSafetyOptions } from './features/datasafety/datasafety.js';
 export {
   dataEntrySchema,
@@ -127,7 +127,7 @@ import { reviewsAll } from './features/reviews/reviewsAll.js';
 import { searchIterator } from './features/search/searchIterator.js';
 import { developerIterator } from './features/developer/developerIterator.js';
 import { permissions } from './features/permissions/permissions.js';
-import { datasafety } from './features/datasafety/datasafety.js';
+import { dataSafety } from './features/datasafety/datasafety.js';
 import { memoized } from './features/memoized/memoized.js';
 import { createClient } from './client.js';
 
@@ -150,7 +150,7 @@ export interface GooglePlayClient {
   similar: typeof similar;
   reviews: typeof reviews;
   permissions: typeof permissions;
-  datasafety: typeof datasafety;
+  dataSafety: typeof dataSafety;
 }
 
 export interface GooglePlayIterators {
@@ -187,7 +187,7 @@ const gplay: GooglePlayClient &
   searchIterator,
   developerIterator,
   permissions,
-  datasafety,
+  dataSafety,
   memoized,
   createClient,
 };


### PR DESCRIPTION
## Summary

A last-chance API-surface pass before 1.0, where every rename costs a major. The public surface is already consistent — compound names use camelCase everywhere (`reviewsIterator`, `searchIterator`, `createClient`, `createCountryFetch`). The one outlier was `datasafety`, whose own schemas and types were *already* camelCase (`dataSafetyOptionsSchema`, `dataSafetySchema`, `DataSafety`, `DataSafetyOptions`) — only the function and method lagged.

This renames the function/method to `dataSafety` to close that gap.

## Changes

- **Programmatic API**: `datasafety` → `dataSafety` for the named export, the `createClient().dataSafety()` method, the `gplay.dataSafety()` aggregate default-export method, and `memoized().dataSafety()`. Internal factory `createDatasafety` → `createDataSafety`.
- **CLI verb**: `datasafety` → `data-safety` (kebab-case, following CLI conventions). The command now dispatches to `api.dataSafety` while the verb reads `data-safety`, decoupling the previously strict command-name = method-name invariant.
- Updated tests, README, and examples to match.

## Deliberately left unchanged

- **Google Play URL path** `/store/apps/datasafety` — Google's own URL, not our surface.
- **`features/datasafety/` folder and file paths** — internal, not part of the public typedoc surface.
- **Result field names** `descriptionHTML`, `developerInternalID`, `offersIAP`, `IAPRange` — copied verbatim from `google-play-scraper` as the drop-in data contract. Internally inconsistent with `privacyPolicyUrl`/`appId`, but renaming them would break output compatibility, which is the point of the aggregate default export. Accepted as a conscious trade-off.

## Breaking changes

- The `datasafety` export and `gplay.datasafety` method are renamed to `dataSafety`.
- The CLI subcommand `datasafety` is renamed to `data-safety`.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm build` — clean
- `pnpm test:coverage` — 518/518 unit tests pass, 99.75% statement coverage
- `pnpm test:e2e` — 107/107 live tests pass against play.google.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the data safety API method from `datasafety` to `dataSafety`.
  * Renamed the CLI command from `datasafety` to `data-safety`.
  * Updated examples and documentation to use the new names.
* **Bug Fixes**
  * Corrected data safety references in CLI help output and documentation links.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->