### PR TITLE
test(e2e): expand live contract coverage for localized edge cases

### DIFF
--- a/e2e/app.e2e.test.ts
+++ b/e2e/app.e2e.test.ts
@@ -115,7 +115,7 @@ liveDescribe('app live contract', () => {
     expect(result.free).toBe(true);
     expect(result.price).toBe(0);
     expect(result.offersIAP).toBe(true);
-    expect(result.IAPRange).toBeDefined();
+    expect(result.IAPRange?.trim().length).toBeGreaterThan(0);
     expect(result.adSupported).toBe(true);
     expect(result.preregister).toBe(false);
     expect(result.available).toBe(true);
@@ -141,10 +141,10 @@ liveDescribe('app live contract', () => {
       country: 'de',
     });
 
-    expect(result.developerLegalName).toBeDefined();
-    expect(result.developerLegalEmail).toBeDefined();
-    expect(result.developerLegalAddress).toBeDefined();
-    expect(result.developerLegalPhoneNumber).toBeDefined();
+    expect(result.developerLegalName?.trim().length).toBeGreaterThan(0);
+    expect(result.developerLegalEmail?.trim().length).toBeGreaterThan(0);
+    expect(result.developerLegalAddress?.trim().length).toBeGreaterThan(0);
+    expect(result.developerLegalPhoneNumber?.trim().length).toBeGreaterThan(0);
   });
 
   it('rejects a nonexistent package with a NotFoundError', async () => {

--- a/e2e/app.e2e.test.ts
+++ b/e2e/app.e2e.test.ts
@@ -109,6 +109,44 @@ liveDescribe('app live contract', () => {
     }
   });
 
+  it('reports the free with ads and purchases commercial model', async () => {
+    const result = await liveClient.app({ appId: 'com.king.candycrushsaga' });
+
+    expect(result.free).toBe(true);
+    expect(result.price).toBe(0);
+    expect(result.offersIAP).toBe(true);
+    expect(result.IAPRange).toBeDefined();
+    expect(result.adSupported).toBe(true);
+    expect(result.preregister).toBe(false);
+    expect(result.available).toBe(true);
+  });
+
+  it('localizes the paid price into the storefront currency', async () => {
+    const result = await liveClient.app({
+      appId: 'com.mojang.minecraftpe',
+      lang: 'de',
+      country: 'de',
+    });
+
+    expect(result.free).toBe(false);
+    expect(result.price).toBeGreaterThan(0);
+    expect(result.currency).toBe('EUR');
+    expect(result.priceText).toContain('€');
+  });
+
+  it('exposes the trader legal fields on an eu storefront', async () => {
+    const result = await liveClient.app({
+      appId: 'com.google.android.apps.translate',
+      lang: 'de',
+      country: 'de',
+    });
+
+    expect(result.developerLegalName).toBeDefined();
+    expect(result.developerLegalEmail).toBeDefined();
+    expect(result.developerLegalAddress).toBeDefined();
+    expect(result.developerLegalPhoneNumber).toBeDefined();
+  });
+
   it('rejects a nonexistent package with a NotFoundError', async () => {
     await expect(
       liveClient.app({ appId: 'com.adex77.definitely.not.a.real.app' }),

--- a/e2e/apps.e2e.test.ts
+++ b/e2e/apps.e2e.test.ts
@@ -21,6 +21,19 @@ liveDescribe('apps live contract', () => {
     }
   });
 
+  it('rejects every entry in order when no id exists', async () => {
+    const missingIds = ['com.adex77.definitely.not.a.real.app', 'com.adex77.also.not.real'];
+    const result = await liveClient.apps({ appIds: missingIds, concurrency: 2 });
+
+    expect(result.map((entry) => entry.appId)).toEqual(missingIds);
+    for (const entry of result) {
+      expect(entry.status).toBe('rejected');
+      if (entry.status === 'rejected') {
+        expect(entry.error).toBeInstanceOf(NotFoundError);
+      }
+    }
+  });
+
   it('rejects only the missing id while the rest fulfill', async () => {
     const missingId = 'com.adex77.definitely.not.a.real.app';
     const result = await liveClient.apps({

--- a/e2e/datasafety.e2e.test.ts
+++ b/e2e/datasafety.e2e.test.ts
@@ -49,17 +49,26 @@ liveDescribe('datasafety live contract', () => {
     expect(result.sharedData.some((entry) => entry.purpose !== undefined)).toBe(true);
   });
 
-  it('localizes the safety report for a polish storefront', async () => {
-    const result = await liveClient.dataSafety({ appId: 'com.adex77.WhereAmI', lang: 'pl' });
+  it('localizes the safety report labels for a polish storefront', async () => {
+    const defaultReport = await liveClient.dataSafety({ appId: 'com.adex77.WhereAmI' });
+    const polishReport = await liveClient.dataSafety({ appId: 'com.adex77.WhereAmI', lang: 'pl' });
 
-    expect(result.collectedData.length).toBeGreaterThan(0);
-    expect(result.securityPractices.length).toBeGreaterThan(0);
-    for (const entry of result.collectedData) {
+    expect(polishReport.collectedData.length).toBe(defaultReport.collectedData.length);
+    expect(polishReport.securityPractices.length).toBe(defaultReport.securityPractices.length);
+    expect(polishReport.collectedData.length).toBeGreaterThan(0);
+    expect(polishReport.securityPractices.length).toBeGreaterThan(0);
+
+    const defaultTypes = defaultReport.collectedData.map((entry) => entry.type);
+    const polishTypes = polishReport.collectedData.map((entry) => entry.type);
+    expect(polishTypes).not.toEqual(defaultTypes);
+
+    const defaultPractices = defaultReport.securityPractices.map((entry) => entry.practice);
+    const polishPractices = polishReport.securityPractices.map((entry) => entry.practice);
+    expect(polishPractices).not.toEqual(defaultPractices);
+
+    for (const entry of polishReport.collectedData) {
       expect(entry.data.length).toBeGreaterThan(0);
       expect(entry.type.length).toBeGreaterThan(0);
-    }
-    for (const practice of result.securityPractices) {
-      expect(practice.practice.length).toBeGreaterThan(0);
     }
   });
 

--- a/e2e/datasafety.e2e.test.ts
+++ b/e2e/datasafety.e2e.test.ts
@@ -36,6 +36,33 @@ liveDescribe('datasafety live contract', () => {
     expect(result.privacyPolicyUrl?.startsWith('http')).toBe(true);
   });
 
+  it('returns shared data entries with purposes for a data rich social app', async () => {
+    const result = await liveClient.dataSafety({ appId: 'com.instagram.android' });
+
+    expect(result.sharedData.length).toBeGreaterThan(0);
+    expect(result.collectedData.length).toBeGreaterThan(10);
+    for (const entry of result.sharedData) {
+      expect(entry.data.length).toBeGreaterThan(0);
+      expect(entry.type.length).toBeGreaterThan(0);
+      expect(typeof entry.optional).toBe('boolean');
+    }
+    expect(result.sharedData.some((entry) => entry.purpose !== undefined)).toBe(true);
+  });
+
+  it('localizes the safety report for a polish storefront', async () => {
+    const result = await liveClient.dataSafety({ appId: 'com.adex77.WhereAmI', lang: 'pl' });
+
+    expect(result.collectedData.length).toBeGreaterThan(0);
+    expect(result.securityPractices.length).toBeGreaterThan(0);
+    for (const entry of result.collectedData) {
+      expect(entry.data.length).toBeGreaterThan(0);
+      expect(entry.type.length).toBeGreaterThan(0);
+    }
+    for (const practice of result.securityPractices) {
+      expect(practice.practice.length).toBeGreaterThan(0);
+    }
+  });
+
   it('returns an empty report instead of throwing for a missing app', async () => {
     const result = await liveClient.dataSafety({
       appId: 'com.adex77.definitely.not.a.real.app',

--- a/e2e/developer.e2e.test.ts
+++ b/e2e/developer.e2e.test.ts
@@ -81,6 +81,17 @@ liveDescribe('developer live contract', () => {
     }
   });
 
+  it('resolves a developer name containing a comma and space', async () => {
+    const items = (await liveClient.developer({ devId: 'Netflix, Inc.' })) as DeveloperApp[];
+
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.map((item) => item.appId)).toContain('com.netflix.mediaclient');
+    for (const item of items) {
+      expect(item.developer).toBe('Netflix, Inc.');
+      expect(new URL(item.url).origin).toBe('https://play.google.com');
+    }
+  });
+
   it('rejects an unknown numeric developer id with a NotFoundError', async () => {
     await expect(liveClient.developer({ devId: '9999999999999999999' })).rejects.toBeInstanceOf(
       NotFoundError,

--- a/e2e/iterators.e2e.test.ts
+++ b/e2e/iterators.e2e.test.ts
@@ -72,6 +72,17 @@ liveDescribe('iterators live contract', () => {
     expect(new Set(collected).size).toBe(collected.length);
   });
 
+  it('terminates the reviews stream without items for a missing app', async () => {
+    const collected: string[] = [];
+    for await (const review of liveClient.reviewsIterator({
+      appId: 'com.adex77.definitely.not.a.real.app',
+    })) {
+      collected.push(review.id);
+    }
+
+    expect(collected).toEqual([]);
+  });
+
   it('collects exactly maxReviews reviews through reviewsAll', async () => {
     const reviews = await liveClient.reviewsAll({ appId: WHATSAPP, maxReviews: 50 });
 

--- a/e2e/list.e2e.test.ts
+++ b/e2e/list.e2e.test.ts
@@ -59,6 +59,21 @@ liveDescribe('list live contract', () => {
     }
   });
 
+  it('returns paid games for the top paid game collection', async () => {
+    const items = (await liveClient.list({
+      collection: 'TOP_PAID',
+      category: 'GAME',
+      num: 5,
+    })) as ListItem[];
+
+    expect(items).toHaveLength(5);
+    for (const item of items) {
+      assertValidItem(item);
+      expect(item.free).toBe(false);
+      expect(item.price).toBeGreaterThan(0);
+    }
+  });
+
   it('returns five valid apps for the grossing collection', async () => {
     const items = (await liveClient.list({ collection: 'GROSSING', num: 5 })) as ListItem[];
 

--- a/e2e/permissions.e2e.test.ts
+++ b/e2e/permissions.e2e.test.ts
@@ -40,6 +40,17 @@ liveDescribe('permissions live contract', () => {
     }
   });
 
+  it('returns localized permission names for a german storefront', async () => {
+    const result = await liveClient.permissions({ appId: TRANSLATE, lang: 'de' });
+
+    expect(result.length).toBeGreaterThan(3);
+    for (const entry of result) {
+      const item = entry as { permission: string; type: number };
+      expect(item.permission.length).toBeGreaterThan(0);
+      expect([permission.COMMON, permission.OTHER]).toContain(item.type);
+    }
+  });
+
   it('returns an empty list instead of throwing for a missing app', async () => {
     const result = await liveClient.permissions({
       appId: 'com.adex77.definitely.not.a.real.app',

--- a/e2e/reviews.e2e.test.ts
+++ b/e2e/reviews.e2e.test.ts
@@ -69,6 +69,36 @@ liveDescribe('reviews live contract', () => {
     });
   });
 
+  it('returns the newest sort in non increasing date order', async () => {
+    const result = await liveClient.reviews({ appId: 'com.whatsapp', paginate: true });
+
+    expect(result.data.length).toBeGreaterThan(100);
+    const timestamps = result.data.map((review) => Date.parse(review.date));
+    for (const [index, timestamp] of timestamps.entries()) {
+      if (index > 0) {
+        expect(timestamp).toBeLessThanOrEqual(timestamps[index - 1]!);
+      }
+    }
+  });
+
+  it('returns a localized first page for a polish storefront', async () => {
+    const result = await liveClient.reviews({
+      appId: 'com.whatsapp',
+      paginate: true,
+      lang: 'pl',
+      country: 'pl',
+    });
+
+    expect(result.data.length).toBeGreaterThan(100);
+    expect(result.nextPaginationToken).not.toBeNull();
+    for (const review of result.data) {
+      expect(review.id.length).toBeGreaterThan(0);
+      expect(review.score).toBeGreaterThanOrEqual(1);
+      expect(review.score).toBeLessThanOrEqual(5);
+      expect(Number.isNaN(Date.parse(review.date))).toBe(false);
+    }
+  });
+
   it('returns an empty page instead of throwing for a missing app', async () => {
     const result = await liveClient.reviews({
       appId: 'com.adex77.definitely.not.a.real.app',

--- a/e2e/reviews.e2e.test.ts
+++ b/e2e/reviews.e2e.test.ts
@@ -81,22 +81,27 @@ liveDescribe('reviews live contract', () => {
     }
   });
 
-  it('returns a localized first page for a polish storefront', async () => {
-    const result = await liveClient.reviews({
+  it('serves a disjoint localized first page for a polish storefront', async () => {
+    const defaultPage = await liveClient.reviews({ appId: 'com.whatsapp', paginate: true });
+    const polishPage = await liveClient.reviews({
       appId: 'com.whatsapp',
       paginate: true,
       lang: 'pl',
       country: 'pl',
     });
 
-    expect(result.data.length).toBeGreaterThan(100);
-    expect(result.nextPaginationToken).not.toBeNull();
-    for (const review of result.data) {
+    expect(polishPage.data.length).toBeGreaterThan(100);
+    expect(polishPage.nextPaginationToken).not.toBeNull();
+    for (const review of polishPage.data) {
       expect(review.id.length).toBeGreaterThan(0);
       expect(review.score).toBeGreaterThanOrEqual(1);
       expect(review.score).toBeLessThanOrEqual(5);
       expect(Number.isNaN(Date.parse(review.date))).toBe(false);
     }
+
+    const defaultIds = new Set(defaultPage.data.map((review) => review.id));
+    const overlap = polishPage.data.filter((review) => defaultIds.has(review.id)).length;
+    expect(overlap).toBeLessThan(15);
   });
 
   it('returns an empty page instead of throwing for a missing app', async () => {

--- a/e2e/search.e2e.test.ts
+++ b/e2e/search.e2e.test.ts
@@ -78,6 +78,22 @@ liveDescribe('search live contract', () => {
     }
   });
 
+  it('returns localized results for a german term with diacritics', async () => {
+    const results = (await liveClient.search({
+      term: 'übersetzer',
+      lang: 'de',
+      country: 'de',
+      num: 20,
+    })) as SearchResult[];
+
+    expect(results.length).toBeGreaterThanOrEqual(10);
+    expect(results.some((item) => item.title.toLowerCase().includes('übersetzer'))).toBe(true);
+    for (const item of results) {
+      expect(item.appId.length).toBeGreaterThan(0);
+      expect(item.title.length).toBeGreaterThan(0);
+    }
+  });
+
   it('serves at least the full first page when num exceeds the google cap', async () => {
     const events: DegradationEvent[] = [];
     const results = (await liveClient.search({


### PR DESCRIPTION
## Summary

Expands the live contract suite from 107 to 120 tests ahead of the 1.0 release. Every new assertion pins a value measured against Google Play on 2026-07-17, following the contract-pinning rules from plan steps 21 and 24, and stays within the non-goals recorded there.

## New contracts

**app**
- Free-with-ads-and-purchases commercial model (`com.king.candycrushsaga`): `free`, `offersIAP`, `IAPRange`, `adSupported` pinned together.
- Localized paid pricing on the German storefront (`com.mojang.minecraftpe`, de/de): `currency` is `EUR` and `priceText` carries the localized symbol.
- EU trader legal fields (de/de): `developerLegalName`, `developerLegalEmail`, `developerLegalAddress`, `developerLegalPhoneNumber` are all served.

**apps**
- An all-missing batch rejects every entry with `NotFoundError` while preserving input order.

**reviews / iterators**
- The default `NEWEST` sort serves the first page in non-increasing date order.
- A localized first page (pl/pl) parses with valid scores, ids, and dates, and still serves a continuation token.
- `reviewsIterator` on a missing app terminates immediately with zero items instead of hanging or throwing.

**dataSafety**
- A data-rich social app (`com.instagram.android`) serves non-empty `sharedData` with purposes alongside 10+ collected entries.
- A localized report (pl) parses with non-empty labels and security practices.

**search / permissions / list**
- A German term with diacritics (`übersetzer`, de/de) returns localized results.
- Localized permission names (de) keep the `COMMON`/`OTHER` type contract.
- `TOP_PAID` + `GAME` returns exactly `num` items, all paid.

**developer**
- A developer name containing a comma and space (`Netflix, Inc.`) URL-encodes correctly and resolves the catalog.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm format:check`: pass
- `pnpm test:coverage`: 518 unit tests pass, 99.75% statements
- `pnpm test:e2e`: 120/120 pass live (120s at throttle 1)
- `pnpm build` and `pnpm check:package`: publint and attw clean

All candidate contracts were probed live before being pinned; assertions carry margins against the measured values so the daily run stays stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded live contract e2e coverage for app pricing/free-with-ads-and-IAP, storefront localization (currency/price text), and EU developer legal details.
  * Added scenarios for fully missing app IDs (order preserved, all rejected), iterator behavior for non-existent reviews, and paid/top-paid listings (count, non-free, positive price).
  * Strengthened localization checks for permissions, search with diacritics, and reviews (pagination/date ordering plus localized vs default disjointness). Added additional data safety field assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->