### PR TITLE
fix(reviews): pad nanoseconds before deriving date milliseconds

### DIFF
--- a/src/features/reviews/reviews.test.ts
+++ b/src/features/reviews/reviews.test.ts
@@ -239,6 +239,35 @@ describe('reviews degraded payloads', () => {
     expect(result.data[0]?.replyText).toBe('thanks');
   });
 
+  it('drops a reply date with fractional seconds or out of range nanoseconds', async () => {
+    const fractional = reviewEntry('r1');
+    fractional[7] = [null, 'thanks', [77.5, 0]];
+    const overflow = reviewEntry('r2');
+    overflow[7] = [null, 'thanks', [1700000100, 1000000000]];
+
+    const result = await reviews({
+      appId: TRANSLATE,
+      paginate: true,
+      requestOptions: { fetchImpl: fetchReturning(reviewsBatch([fractional, overflow], null)) },
+    });
+
+    expect(result.data[0]?.replyDate).toBeUndefined();
+    expect(result.data[1]?.replyDate).toBeUndefined();
+  });
+
+  it('keeps a reply date at the nanosecond upper bound', async () => {
+    const entry = reviewEntry('r1');
+    entry[7] = [null, 'thanks', [1700000100, 999999999]];
+
+    const result = await reviews({
+      appId: TRANSLATE,
+      paginate: true,
+      requestOptions: { fetchImpl: fetchReturning(reviewsBatch([entry], null)) },
+    });
+
+    expect(result.data[0]?.replyDate).toBe('2023-11-14T22:15:00.999Z');
+  });
+
   it('surfaces a SpecError when a criteria entry is not an array', async () => {
     const entry = reviewEntry('r1');
     entry[12] = [['bogus-criteria']];

--- a/src/features/reviews/reviews.test.ts
+++ b/src/features/reviews/reviews.test.ts
@@ -62,6 +62,18 @@ describe('reviews fixture parsing', () => {
     }
   });
 
+  it('derives sub second milliseconds from a nanosecond field shorter than nine digits', async () => {
+    const result = await reviews({
+      appId: TRANSLATE,
+      num: 150,
+      requestOptions: { fetchImpl: fetchReturning(initial) },
+    });
+
+    const dates = result.data.map((review) => review.date);
+    expect(dates).toContain('2026-07-06T13:55:24.077Z');
+    expect(dates).not.toContain('2026-07-06T13:55:24.770Z');
+  });
+
   it('accumulates across both pages and slices to the requested num', async () => {
     const { fetchImpl, count } = sequenceFetch([initial, page2]);
 

--- a/src/features/reviews/specs.ts
+++ b/src/features/reviews/specs.ts
@@ -41,10 +41,9 @@ function generateDate(value: unknown): string | undefined {
   }
   const seconds = Number(value[0]);
   const nanos = Number(value[1]);
-  const nanoText = (Number.isFinite(nanos) && nanos !== 0 ? nanos.toString() : '000').substring(
-    0,
-    3,
-  );
+  const nanoText = (
+    Number.isFinite(nanos) && nanos !== 0 ? nanos.toString().padStart(9, '0') : '000'
+  ).substring(0, 3);
   const milliseconds = Number(`${seconds.toString()}${nanoText}`);
   const date = new Date(milliseconds);
   return Number.isNaN(date.getTime()) ? undefined : date.toISOString();

--- a/src/features/reviews/specs.ts
+++ b/src/features/reviews/specs.ts
@@ -1,3 +1,4 @@
+import * as z from 'zod/mini';
 import { BASE_URL } from '../../constants.js';
 import type { Path } from '../../core/path.js';
 import type { SpecMap } from '../../core/spec.js';
@@ -35,16 +36,26 @@ interface RawCriteria {
   rating: unknown;
 }
 
+const MILLISECONDS_PER_SECOND = 1000;
+const NANOSECONDS_PER_MILLISECOND = 1_000_000;
+const MAX_NANOSECONDS = 999_999_999;
+
+const dateTupleSchema = z.tuple(
+  [
+    z.int().check(z.gte(0)),
+    z.optional(z.nullable(z.int().check(z.gte(0), z.lte(MAX_NANOSECONDS)))),
+  ],
+  z.unknown(),
+);
+
 function generateDate(value: unknown): string | undefined {
-  if (!Array.isArray(value)) {
+  const parsed = dateTupleSchema.safeParse(value);
+  if (!parsed.success) {
     return undefined;
   }
-  const seconds = Number(value[0]);
-  const nanos = Number(value[1]);
-  const nanoText = (
-    Number.isFinite(nanos) && nanos !== 0 ? nanos.toString().padStart(9, '0') : '000'
-  ).substring(0, 3);
-  const milliseconds = Number(`${seconds.toString()}${nanoText}`);
+  const [seconds, nanos] = parsed.data;
+  const milliseconds =
+    seconds * MILLISECONDS_PER_SECOND + Math.floor((nanos ?? 0) / NANOSECONDS_PER_MILLISECOND);
   const date = new Date(milliseconds);
   return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
 }


### PR DESCRIPTION
## Problem

The `reviews` newest-sort e2e test failed intermittently:

```
AssertionError: expected 1784211161760 to be less than or equal to 1784211161272
 ❯ e2e/reviews.e2e.test.ts:79
```

This was **not flaky** — it caught a real date-parsing bug.

## Root cause

Google returns each review timestamp as `[seconds, nanoseconds]`. `generateDate` in `src/features/reviews/specs.ts` derived the millisecond part by slicing the first three characters of the nanoseconds *string*:

```ts
nanos.toString().substring(0, 3)
```

That is only correct when nanos is exactly 9 digits. When it is shorter — e.g. `77000000` (77 ms) — `"77000000".substring(0, 3)` yields `"770"`, so a review at `.077s` is parsed as `.770s`. Sub-second values were inflated by up to 100×, which inverted the ordering of reviews landing in the same second and broke the non-increasing-date assertion on the newest sort.

The pinned reference library carries the same latent bug; the original port copied it verbatim. A fixture review with `nanos 77000000` confirmed the case.

## Fix

Zero-pad the nanoseconds to 9 digits before slicing, making it equivalent to `floor(nanos / 1e6)`:

```ts
nanos.toString().padStart(9, '0').substring(0, 3)
```

The e2e assertion was left untouched — it was correctly detecting the defect.

## Testing

- Added an offline unit test pinning the short-nanos case (`.077Z` derived, not `.770Z`).
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (519 unit tests), and `pnpm build` all pass.
- `pnpm test:e2e -- reviews`: 120/120 pass, including the newest-sort ordering test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected review timestamp conversion to ensure nanosecond precision is translated accurately into millisecond precision.
  * Improved handling of boundary and malformed sub-second values so invalid reply dates are omitted while valid upper-bound timestamps are preserved.

* **Tests**
  * Added assertions covering shortened nanosecond decoding and degraded payload boundary cases to confirm correct timestamp retention or removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->