### PR TITLE
test(search): tolerate google first-page count oscillation

### DIFF
--- a/e2e/search.e2e.test.ts
+++ b/e2e/search.e2e.test.ts
@@ -1,10 +1,29 @@
 import { expect, it } from 'vitest';
-import { clientFromOptions } from '../src/core/http.js';
-import { fetchSearchFirstPage } from '../src/features/search/search.js';
+import { clientFromOptions, type HttpClient, type ResolveClient } from '../src/core/http.js';
+import { app } from '../src/features/app/app.js';
+import { createSearch, fetchSearchFirstPage } from '../src/features/search/search.js';
 import { type App, type DegradationEvent, type SearchResult } from '../src/index.js';
 import { expectFieldCoverage, liveClient, liveDescribe } from './helpers.js';
 
 const FIRST_PAGE_CEILING = 40;
+
+function memoizingResolveClient(): ResolveClient {
+  const underlying = clientFromOptions({ throttle: 1 });
+  const cache = new Map<string, Promise<string>>();
+  const client: HttpClient = {
+    request(req) {
+      const key = `${req.method ?? 'GET'} ${req.url} ${req.body ?? ''}`;
+      const cached = cache.get(key);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const pending = underlying.request(req);
+      cache.set(key, pending);
+      return pending;
+    },
+  };
+  return () => client;
+}
 
 liveDescribe('search live contract', () => {
   it('returns unique valid apps for a broad term', async () => {
@@ -98,23 +117,29 @@ liveDescribe('search live contract', () => {
 
   it('serves the full first page without truncation when num exceeds the google cap', async () => {
     const events: DegradationEvent[] = [];
+    const resolveClient = memoizingResolveClient();
+    const search = createSearch(app, resolveClient);
+
     const { page } = await fetchSearchFirstPage(
       { term: 'game', lang: 'en', country: 'us', price: 'all', throttle: 1 },
-      clientFromOptions,
+      resolveClient,
     );
 
     expect(page.token).toBeUndefined();
     expect(page.apps.length).toBeGreaterThan(10);
+    expect(page.apps.length).toBeLessThanOrEqual(FIRST_PAGE_CEILING);
 
-    const results = (await liveClient.search({
+    const results = (await search({
       term: 'game',
       num: 100,
       onDegradation: (event) => events.push(event),
     })) as SearchResult[];
 
-    expect(results.length).toBeGreaterThan(10);
-    expect(results.length).toBeLessThanOrEqual(FIRST_PAGE_CEILING);
-    expect(new Set(results.map((item) => item.appId)).size).toBe(results.length);
+    const firstPageIds = page.apps.map((item) => item.appId);
+    const resultIds = results.map((item) => item.appId);
+
+    expect(resultIds).toEqual(firstPageIds);
+    expect(new Set(resultIds).size).toBe(resultIds.length);
     expectFieldCoverage('search', results, {
       score: 0.8,
       scoreText: 0.8,

--- a/e2e/search.e2e.test.ts
+++ b/e2e/search.e2e.test.ts
@@ -4,6 +4,8 @@ import { fetchSearchFirstPage } from '../src/features/search/search.js';
 import { type App, type DegradationEvent, type SearchResult } from '../src/index.js';
 import { expectFieldCoverage, liveClient, liveDescribe } from './helpers.js';
 
+const FIRST_PAGE_CEILING = 40;
+
 liveDescribe('search live contract', () => {
   it('returns unique valid apps for a broad term', async () => {
     const results = (await liveClient.search({ term: 'panda', num: 30 })) as SearchResult[];
@@ -94,15 +96,24 @@ liveDescribe('search live contract', () => {
     }
   });
 
-  it('serves at least the full first page when num exceeds the google cap', async () => {
+  it('serves the full first page without truncation when num exceeds the google cap', async () => {
     const events: DegradationEvent[] = [];
+    const { page } = await fetchSearchFirstPage(
+      { term: 'game', lang: 'en', country: 'us', price: 'all', throttle: 1 },
+      clientFromOptions,
+    );
+
+    expect(page.token).toBeUndefined();
+    expect(page.apps.length).toBeGreaterThan(10);
+
     const results = (await liveClient.search({
       term: 'game',
       num: 100,
       onDegradation: (event) => events.push(event),
     })) as SearchResult[];
 
-    expect(results.length).toBeGreaterThanOrEqual(25);
+    expect(results.length).toBeGreaterThan(10);
+    expect(results.length).toBeLessThanOrEqual(FIRST_PAGE_CEILING);
     expect(new Set(results.map((item) => item.appId)).size).toBe(results.length);
     expectFieldCoverage('search', results, {
       score: 0.8,


### PR DESCRIPTION
Closes #82

## Root cause

The daily live run flapped on `serves at least the full first page when num exceeds the google cap`: `expected 21 to be greater than or equal to 25`.

Probing live Google Play showed the real cause: **the search first-page app count oscillates per request for the same query.** For `game`, back-to-back identical requests returned either **21 or 30** apps (one probe pair got 30 from the page fetch and 21 from the paired search). The observed band across terms is 19–30 (panda 19–20, music/puzzle 22, racing 23, vpn/photo/weather 30).

This is **not a parse regression**:

- `search()` returns exactly what the section serves — `unique == total`, nothing dropped.
- Only one app-bearing section exists (`[ds:4,0,1][*][22,0]`); no second section is missed.
- No continuation token is served — the `confirms google still serves no search continuation token` tripwire still passes, so the serving regime is unchanged.

The `>= 25` threshold sat **inside** the 21–30 oscillation band, so it was guaranteed to fail intermittently. Per `docs/RUNBOOK.md`, recalibrating a live threshold is the sanctioned action when the cause is server-side serving variance rather than a broken path.

## Fix

Rewrote the test to assert the invariant that actually holds, immune to the count oscillation:

- Fetch the first page directly → assert **no token** (regime intact) and the page has substance (`> 10`).
- `search({ num: 100 })` returns the **full first page without truncation**: floor `> 10` (the threshold the sibling broad-term test already trusts, safely below the 19 floor) and a `FIRST_PAGE_CEILING = 40` guard that catches a revived pagination RPC over-fetching toward `num`.
- Kept the uniqueness, field-coverage, and no-degradation assertions.

The flap came from a magic number living in the oscillation band; the new assertions are tied to the structural invariant (full first page, no token, no over-fetch), so 19–30 variance can never fail it while a genuine regression still does.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm build`: pass
- Live e2e search suite: 10/10, run 3× to confirm stability against the oscillation
- Unit suite: 521/521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end “live contract” search coverage by aligning expectations with the provider’s first-page result ceiling.
  * Added assertions that the first page returns no continuation token, returns a page size within the allowed range, and that requesting a large `num` yields exactly the same unique app IDs as the fetched first page.
  * Continued to verify degradation tracking remains empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->