### PR TITLE
fix(core): parse preregistration listings that carry no offer node

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,22 @@ Returns an `App` with 55 fields. Trimmed:
 }
 ```
 
+A listing that has not been released yet carries no offer at all. For those apps
+`preregister` is `true`, and `price`, `free` and `priceText` fall back to `0`, `false` and
+`'Free'` rather than describing a real offer. Rating, install and release fields are
+absent too. Read `preregister` before trusting any price field:
+
+```ts
+const details = await app({ appId: 'com.ironhidegames.android.kingdomrush6.genesis' });
+
+if (details.preregister) {
+  console.log(`${details.title} has no price yet`);
+}
+```
+
+The same applies to a `search()` row for an unreleased app: it is returned with
+`price: 0` and `free: false`, so a `price: 'free'` filter will not match it.
+
 ### Batch details
 
 Fetches the full detail of many apps in one call, with a concurrency limit and per-id

--- a/docs/FIELD_ABSENCE_AUDIT.md
+++ b/docs/FIELD_ABSENCE_AUDIT.md
@@ -1,134 +1,134 @@
 # Field Absence Audit
 
-| Feature      | Field                       | Policy                                              | Evidence kind    | Evidence                                                    |
-| ------------ | --------------------------- | --------------------------------------------------- | ---------------- | ----------------------------------------------------------- |
-| cluster item | `title`                     | required                                            | established test | paid and priceless cluster item tests provide a title       |
-| cluster item | `appId`                     | required                                            | established test | paid and priceless cluster item tests provide an app id     |
-| cluster item | `url`                       | required                                            | established test | missing link test requires a `SpecError` naming `url`       |
-| cluster item | `icon`                      | required                                            | established test | cluster item builders always provide the icon spine         |
-| cluster item | `developer`                 | required                                            | established test | cluster item builders always provide the developer spine    |
-| cluster item | `currency`                  | optional                                            | established test | missing price cell yields `currency: undefined`             |
-| cluster item | `price`                     | default `0`                                         | established test | missing price cell yields `price: 0`                        |
-| cluster item | `free`                      | default `true`                                      | established test | missing price cell yields `free: true`                      |
-| cluster item | `summary`                   | optional                                            | pinned reference | absent optional item metadata remains undefined             |
-| cluster item | `scoreText`                 | optional                                            | pinned reference | absent optional item metadata remains undefined             |
-| cluster item | `score`                     | optional                                            | pinned reference | absent optional item metadata remains undefined             |
-| app          | `title`                     | required                                            | recorded fixture | present in all app fixtures                                 |
-| app          | `description`               | required                                            | recorded fixture | detail container present in all app fixtures                |
-| app          | `descriptionHTML`           | required                                            | recorded fixture | detail container present in all app fixtures                |
-| app          | `summary`                   | optional                                            | pinned reference | absent optional metadata remains undefined                  |
-| app          | `installs`                  | optional                                            | pinned reference | absent optional metadata remains undefined                  |
-| app          | `minInstalls`               | optional                                            | pinned reference | absent optional metadata remains undefined                  |
-| app          | `maxInstalls`               | optional                                            | pinned reference | absent optional metadata remains undefined                  |
-| app          | `score`                     | optional                                            | pinned reference | unrated listings may omit score metadata                    |
-| app          | `scoreText`                 | optional                                            | pinned reference | unrated listings may omit score metadata                    |
-| app          | `ratings`                   | optional                                            | pinned reference | unrated listings may omit rating counts                     |
-| app          | `reviews`                   | optional                                            | pinned reference | listings may omit review counts                             |
-| app          | `histogram`                 | default zeroed                                      | established test | unrated listings yield a zero filled histogram              |
-| app          | `price`                     | required                                            | recorded fixture | price micros present in all app fixtures                    |
-| app          | `originalPrice`             | optional                                            | recorded fixture | absent in all app fixtures without an active discount       |
-| app          | `discountEndDate`           | optional                                            | established test | discount timestamp parses, non numeric timestamp rejects    |
-| app          | `free`                      | required                                            | recorded fixture | price micros present in all app fixtures                    |
-| app          | `currency`                  | optional                                            | pinned reference | absent currency remains undefined                           |
-| app          | `priceText`                 | required                                            | recorded fixture | price text present in all app fixtures                      |
-| app          | `available`                 | default `false`                                     | established test | absent availability source yields an unavailable listing    |
-| app          | `offersIAP`                 | optional                                            | recorded fixture | absent in `translate.html`                                  |
-| app          | `IAPRange`                  | optional                                            | recorded fixture | absent in `translate.html`                                  |
-| app          | `androidVersion`            | default `VARY`                                      | established test | absent version block yields `VARY`                          |
-| app          | `androidVersionText`        | default `Varies with device`                        | established test | absent version block yields the device-varying label        |
-| app          | `androidMaxVersion`         | default `VARY`                                      | recorded fixture | absent in all three app fixtures                            |
-| app          | `developer`                 | required                                            | recorded fixture | present in all app fixtures                                 |
-| app          | `developerId`               | required                                            | recorded fixture | developer link present in all app fixtures                  |
-| app          | `developerEmail`            | optional                                            | established test | absent developer section yields undefined                   |
-| app          | `developerWebsite`          | optional                                            | pinned reference | absent optional contact metadata remains undefined          |
-| app          | `developerAddress`          | optional                                            | recorded fixture | absent in all three app fixtures                            |
-| app          | `developerLegalName`        | optional                                            | pinned reference | absent optional legal metadata remains undefined            |
-| app          | `developerLegalEmail`       | optional                                            | pinned reference | absent optional legal metadata remains undefined            |
-| app          | `developerLegalAddress`     | optional                                            | established test | absent developer section yields undefined                   |
-| app          | `developerLegalPhoneNumber` | optional                                            | established test | absent developer section yields undefined                   |
-| app          | `privacyPolicy`             | optional                                            | pinned reference | absent optional policy link remains undefined               |
-| app          | `developerInternalID`       | required                                            | recorded fixture | developer link present in all app fixtures                  |
-| app          | `genre`                     | required                                            | recorded fixture | present in all app fixtures                                 |
-| app          | `genreId`                   | required                                            | recorded fixture | present in all app fixtures                                 |
-| app          | `categories`                | required                                            | recorded fixture | detail container present in all app fixtures                |
-| app          | `icon`                      | required                                            | recorded fixture | present in all app fixtures                                 |
-| app          | `headerImage`               | optional                                            | pinned reference | absent optional artwork remains undefined                   |
-| app          | `screenshots`               | required                                            | recorded fixture | screenshot collection present in all app fixtures           |
-| app          | `video`                     | optional                                            | recorded fixture | absent in `translate.html`                                  |
-| app          | `videoImage`                | optional                                            | recorded fixture | absent in `translate.html`                                  |
-| app          | `previewVideo`              | optional                                            | recorded fixture | absent in `translate.html`                                  |
-| app          | `contentRating`             | optional                                            | pinned reference | absent optional rating metadata remains undefined           |
-| app          | `contentRatingDescription`  | optional                                            | recorded fixture | absent in `translate.html`                                  |
-| app          | `adSupported`               | default `false`                                     | recorded fixture | absent in `translate.html` and `minecraft.html`             |
-| app          | `released`                  | optional                                            | recorded fixture | absent in `translate.html`                                  |
-| app          | `updated`                   | required                                            | recorded fixture | update timestamp present in all app fixtures                |
-| app          | `version`                   | default `VARY`                                      | established test | absent version block yields `VARY`                          |
-| app          | `recentChanges`             | optional                                            | pinned reference | absent changelog remains undefined                          |
-| app          | `comments`                  | default `[]` declared, unreachable in `app()`       | established test | an absent-marker root yields `[]`, a malformed root rejects |
-| app          | `preregister`               | default `false`                                     | established test | absent availability source yields no preregistration        |
-| app          | `earlyAccessEnabled`        | default `false`                                     | recorded fixture | absent in all three app fixtures                            |
-| app          | `isAvailableInPlayPass`     | default `false`                                     | recorded fixture | absent in all three app fixtures                            |
-| search       | `title`                     | required                                            | recorded fixture | search fixtures populate every result title                 |
-| search       | `appId`                     | required                                            | recorded fixture | search fixtures populate every result app id                |
-| search       | `url`                       | required                                            | recorded fixture | search fixtures populate every result link                  |
-| search       | `icon`                      | required                                            | recorded fixture | search fixtures populate every result icon                  |
-| search       | `developer`                 | required                                            | recorded fixture | search fixtures populate every result developer             |
-| search       | `developerId`               | optional                                            | pinned reference | exact-match developer id may be absent                      |
-| search       | `currency`                  | optional                                            | pinned reference | absent optional currency remains undefined                  |
-| search       | `price`                     | required on results, default `0` on exact match     | established test | priceless exact match yields `price: 0`                     |
-| search       | `free`                      | required on results, default `false` on exact match | established test | priceless exact match yields `free: false`                  |
-| search       | `summary`                   | optional                                            | pinned reference | absent optional summary remains undefined                   |
-| search       | `scoreText`                 | optional                                            | pinned reference | unrated results may omit score metadata                     |
-| search       | `score`                     | optional                                            | pinned reference | unrated results may omit score metadata                     |
-| list         | `title`                     | required                                            | recorded fixture | list fixture populates every item title                     |
-| list         | `appId`                     | required                                            | recorded fixture | list fixture populates every item app id                    |
-| list         | `url`                       | required                                            | established test | missing link test requires a `SpecError` naming `url`       |
-| list         | `icon`                      | required                                            | recorded fixture | list fixture populates every item icon                      |
-| list         | `developer`                 | required                                            | recorded fixture | list fixture populates every item developer                 |
-| list         | `currency`                  | optional                                            | established test | priceless row yields `currency: undefined`                  |
-| list         | `price`                     | default `0`                                         | established test | priceless row yields `price: 0`                             |
-| list         | `free`                      | default `false`                                     | established test | priceless row yields `free: false`                          |
-| list         | `summary`                   | optional                                            | pinned reference | absent optional summary remains undefined                   |
-| list         | `scoreText`                 | optional                                            | pinned reference | unrated rows may omit score metadata                        |
-| list         | `score`                     | optional                                            | pinned reference | unrated rows may omit score metadata                        |
-| developer    | `title`                     | required                                            | recorded fixture | both developer layouts populate item titles                 |
-| developer    | `appId`                     | required                                            | recorded fixture | both developer layouts populate app ids                     |
-| developer    | `url`                       | required                                            | recorded fixture | both developer layouts populate item links                  |
-| developer    | `icon`                      | required                                            | recorded fixture | both developer layouts populate item icons                  |
-| developer    | `developer`                 | required                                            | recorded fixture | both developer layouts populate developer names             |
-| developer    | `currency`                  | optional                                            | pinned reference | absent optional currency remains undefined                  |
-| developer    | `price`                     | default `0`                                         | established test | priceless name-layout row yields `price: 0`                 |
-| developer    | `free`                      | default `false`                                     | established test | priceless name-layout row yields `free: false`              |
-| developer    | `summary`                   | optional                                            | pinned reference | absent optional summary remains undefined                   |
-| developer    | `scoreText`                 | optional                                            | pinned reference | unrated apps may omit score metadata                        |
-| developer    | `score`                     | optional                                            | pinned reference | unrated apps may omit score metadata                        |
-| similar      | `title`                     | required                                            | recorded fixture | similar fixture populates item titles                       |
-| similar      | `appId`                     | required                                            | recorded fixture | similar fixture populates app ids                           |
-| similar      | `url`                       | required                                            | recorded fixture | similar fixture populates item links                        |
-| similar      | `icon`                      | required                                            | recorded fixture | similar fixture populates item icons                        |
-| similar      | `developer`                 | required                                            | recorded fixture | similar fixture populates developer names                   |
-| similar      | `currency`                  | optional                                            | pinned reference | absent optional currency remains undefined                  |
-| similar      | `price`                     | default `0`                                         | established test | priceless similar row yields `price: 0`                     |
-| similar      | `free`                      | default `false`                                     | established test | priceless similar row yields `free: false`                  |
-| similar      | `summary`                   | optional                                            | pinned reference | absent optional summary remains undefined                   |
-| similar      | `scoreText`                 | optional                                            | pinned reference | unrated apps may omit score metadata                        |
-| similar      | `score`                     | optional                                            | pinned reference | unrated apps may omit score metadata                        |
-| reviews      | `id`                        | required                                            | recorded fixture | every recorded review carries an id                         |
-| reviews      | `userName`                  | required                                            | recorded fixture | every recorded review carries a user name                   |
-| reviews      | `userImage`                 | optional                                            | pinned reference | absent optional user image remains undefined                |
-| reviews      | `date`                      | required                                            | recorded fixture | every recorded review carries a date tuple                  |
-| reviews      | `score`                     | required                                            | recorded fixture | every recorded review carries a score                       |
-| reviews      | `title`                     | required                                            | pinned reference | title derives from the required review id source            |
-| reviews      | `text`                      | optional                                            | pinned reference | reviews may omit text                                       |
-| reviews      | `replyDate`                 | optional                                            | pinned reference | reviews without a developer reply omit its date             |
-| reviews      | `replyText`                 | optional                                            | pinned reference | reviews without a developer reply omit its text             |
-| reviews      | `version`                   | optional                                            | pinned reference | reviews may omit the app version                            |
-| reviews      | `thumbsUp`                  | optional                                            | pinned reference | absent optional vote count remains undefined                |
-| reviews      | `criterias`                 | default `[]`                                        | recorded fixture | reviews without criteria retain an empty criteria list      |
-| dataSafety   | `sharedData`                | default `[]`                                        | established test | missing-app response yields an empty report                 |
-| dataSafety   | `collectedData`             | default `[]`                                        | established test | missing-app response yields an empty report                 |
-| dataSafety   | `securityPractices`         | default `[]`                                        | established test | missing-app response yields an empty report                 |
-| dataSafety   | `privacyPolicyUrl`          | optional                                            | established test | missing-app response omits the policy link                  |
+| Feature      | Field                       | Policy                                        | Evidence kind    | Evidence                                                                 |
+| ------------ | --------------------------- | --------------------------------------------- | ---------------- | ------------------------------------------------------------------------ |
+| cluster item | `title`                     | required                                      | established test | paid and priceless cluster item tests provide a title                    |
+| cluster item | `appId`                     | required                                      | established test | paid and priceless cluster item tests provide an app id                  |
+| cluster item | `url`                       | required                                      | established test | missing link test requires a `SpecError` naming `url`                    |
+| cluster item | `icon`                      | required                                      | established test | cluster item builders always provide the icon spine                      |
+| cluster item | `developer`                 | required                                      | established test | cluster item builders always provide the developer spine                 |
+| cluster item | `currency`                  | optional                                      | established test | missing price cell yields `currency: undefined`                          |
+| cluster item | `price`                     | default `0`                                   | established test | missing price cell yields `price: 0`                                     |
+| cluster item | `free`                      | default `true`                                | established test | missing price cell yields `free: true`                                   |
+| cluster item | `summary`                   | optional                                      | pinned reference | absent optional item metadata remains undefined                          |
+| cluster item | `scoreText`                 | optional                                      | pinned reference | absent optional item metadata remains undefined                          |
+| cluster item | `score`                     | optional                                      | pinned reference | absent optional item metadata remains undefined                          |
+| app          | `title`                     | required                                      | recorded fixture | present in all app fixtures                                              |
+| app          | `description`               | required                                      | recorded fixture | detail container present in all app fixtures                             |
+| app          | `descriptionHTML`           | required                                      | recorded fixture | detail container present in all app fixtures                             |
+| app          | `summary`                   | optional                                      | pinned reference | absent optional metadata remains undefined                               |
+| app          | `installs`                  | optional                                      | pinned reference | absent optional metadata remains undefined                               |
+| app          | `minInstalls`               | optional                                      | pinned reference | absent optional metadata remains undefined                               |
+| app          | `maxInstalls`               | optional                                      | pinned reference | absent optional metadata remains undefined                               |
+| app          | `score`                     | optional                                      | pinned reference | unrated listings may omit score metadata                                 |
+| app          | `scoreText`                 | optional                                      | pinned reference | unrated listings may omit score metadata                                 |
+| app          | `ratings`                   | optional                                      | pinned reference | unrated listings may omit rating counts                                  |
+| app          | `reviews`                   | optional                                      | pinned reference | listings may omit review counts                                          |
+| app          | `histogram`                 | default zeroed                                | established test | unrated listings yield a zero filled histogram                           |
+| app          | `price`                     | default `0`                                   | live probe       | preregistration listings carry no offer node, yielding `price: 0`        |
+| app          | `originalPrice`             | optional                                      | recorded fixture | absent in all app fixtures without an active discount                    |
+| app          | `discountEndDate`           | optional                                      | established test | discount timestamp parses, non numeric timestamp rejects                 |
+| app          | `free`                      | default `false`                               | live probe       | preregistration listings carry no offer node, yielding `free: false`     |
+| app          | `currency`                  | optional                                      | pinned reference | absent currency remains undefined                                        |
+| app          | `priceText`                 | default `Free`                                | live probe       | preregistration listings carry no offer node, yielding `priceText: Free` |
+| app          | `available`                 | default `false`                               | established test | absent availability source yields an unavailable listing                 |
+| app          | `offersIAP`                 | optional                                      | recorded fixture | absent in `translate.html`                                               |
+| app          | `IAPRange`                  | optional                                      | recorded fixture | absent in `translate.html`                                               |
+| app          | `androidVersion`            | default `VARY`                                | established test | absent version block yields `VARY`                                       |
+| app          | `androidVersionText`        | default `Varies with device`                  | established test | absent version block yields the device-varying label                     |
+| app          | `androidMaxVersion`         | default `VARY`                                | recorded fixture | absent in all three app fixtures                                         |
+| app          | `developer`                 | required                                      | recorded fixture | present in all app fixtures                                              |
+| app          | `developerId`               | required                                      | recorded fixture | developer link present in all app fixtures                               |
+| app          | `developerEmail`            | optional                                      | established test | absent developer section yields undefined                                |
+| app          | `developerWebsite`          | optional                                      | pinned reference | absent optional contact metadata remains undefined                       |
+| app          | `developerAddress`          | optional                                      | recorded fixture | absent in all three app fixtures                                         |
+| app          | `developerLegalName`        | optional                                      | pinned reference | absent optional legal metadata remains undefined                         |
+| app          | `developerLegalEmail`       | optional                                      | pinned reference | absent optional legal metadata remains undefined                         |
+| app          | `developerLegalAddress`     | optional                                      | established test | absent developer section yields undefined                                |
+| app          | `developerLegalPhoneNumber` | optional                                      | established test | absent developer section yields undefined                                |
+| app          | `privacyPolicy`             | optional                                      | pinned reference | absent optional policy link remains undefined                            |
+| app          | `developerInternalID`       | required                                      | recorded fixture | developer link present in all app fixtures                               |
+| app          | `genre`                     | required                                      | recorded fixture | present in all app fixtures                                              |
+| app          | `genreId`                   | required                                      | recorded fixture | present in all app fixtures                                              |
+| app          | `categories`                | required                                      | recorded fixture | detail container present in all app fixtures                             |
+| app          | `icon`                      | required                                      | recorded fixture | present in all app fixtures                                              |
+| app          | `headerImage`               | optional                                      | pinned reference | absent optional artwork remains undefined                                |
+| app          | `screenshots`               | required                                      | recorded fixture | screenshot collection present in all app fixtures                        |
+| app          | `video`                     | optional                                      | recorded fixture | absent in `translate.html`                                               |
+| app          | `videoImage`                | optional                                      | recorded fixture | absent in `translate.html`                                               |
+| app          | `previewVideo`              | optional                                      | recorded fixture | absent in `translate.html`                                               |
+| app          | `contentRating`             | optional                                      | pinned reference | absent optional rating metadata remains undefined                        |
+| app          | `contentRatingDescription`  | optional                                      | recorded fixture | absent in `translate.html`                                               |
+| app          | `adSupported`               | default `false`                               | recorded fixture | absent in `translate.html` and `minecraft.html`                          |
+| app          | `released`                  | optional                                      | recorded fixture | absent in `translate.html`                                               |
+| app          | `updated`                   | required                                      | recorded fixture | update timestamp present in all app fixtures                             |
+| app          | `version`                   | default `VARY`                                | established test | absent version block yields `VARY`                                       |
+| app          | `recentChanges`             | optional                                      | pinned reference | absent changelog remains undefined                                       |
+| app          | `comments`                  | default `[]` declared, unreachable in `app()` | established test | an absent-marker root yields `[]`, a malformed root rejects              |
+| app          | `preregister`               | default `false`                               | established test | absent availability source yields no preregistration                     |
+| app          | `earlyAccessEnabled`        | default `false`                               | recorded fixture | absent in all three app fixtures                                         |
+| app          | `isAvailableInPlayPass`     | default `false`                               | recorded fixture | absent in all three app fixtures                                         |
+| search       | `title`                     | required                                      | recorded fixture | search fixtures populate every result title                              |
+| search       | `appId`                     | required                                      | recorded fixture | search fixtures populate every result app id                             |
+| search       | `url`                       | required                                      | recorded fixture | search fixtures populate every result link                               |
+| search       | `icon`                      | required                                      | recorded fixture | search fixtures populate every result icon                               |
+| search       | `developer`                 | required                                      | recorded fixture | search fixtures populate every result developer                          |
+| search       | `developerId`               | optional                                      | pinned reference | exact-match developer id may be absent                                   |
+| search       | `currency`                  | optional                                      | pinned reference | absent optional currency remains undefined                               |
+| search       | `price`                     | default `0`                                   | live probe       | a preregistration row carries no offer node, yielding `price: 0`         |
+| search       | `free`                      | default `false`                               | live probe       | a preregistration row carries no offer node, yielding `free: false`      |
+| search       | `summary`                   | optional                                      | pinned reference | absent optional summary remains undefined                                |
+| search       | `scoreText`                 | optional                                      | pinned reference | unrated results may omit score metadata                                  |
+| search       | `score`                     | optional                                      | pinned reference | unrated results may omit score metadata                                  |
+| list         | `title`                     | required                                      | recorded fixture | list fixture populates every item title                                  |
+| list         | `appId`                     | required                                      | recorded fixture | list fixture populates every item app id                                 |
+| list         | `url`                       | required                                      | established test | missing link test requires a `SpecError` naming `url`                    |
+| list         | `icon`                      | required                                      | recorded fixture | list fixture populates every item icon                                   |
+| list         | `developer`                 | required                                      | recorded fixture | list fixture populates every item developer                              |
+| list         | `currency`                  | optional                                      | established test | priceless row yields `currency: undefined`                               |
+| list         | `price`                     | default `0`                                   | established test | priceless row yields `price: 0`                                          |
+| list         | `free`                      | default `false`                               | established test | priceless row yields `free: false`                                       |
+| list         | `summary`                   | optional                                      | pinned reference | absent optional summary remains undefined                                |
+| list         | `scoreText`                 | optional                                      | pinned reference | unrated rows may omit score metadata                                     |
+| list         | `score`                     | optional                                      | pinned reference | unrated rows may omit score metadata                                     |
+| developer    | `title`                     | required                                      | recorded fixture | both developer layouts populate item titles                              |
+| developer    | `appId`                     | required                                      | recorded fixture | both developer layouts populate app ids                                  |
+| developer    | `url`                       | required                                      | recorded fixture | both developer layouts populate item links                               |
+| developer    | `icon`                      | required                                      | recorded fixture | both developer layouts populate item icons                               |
+| developer    | `developer`                 | required                                      | recorded fixture | both developer layouts populate developer names                          |
+| developer    | `currency`                  | optional                                      | pinned reference | absent optional currency remains undefined                               |
+| developer    | `price`                     | default `0`                                   | established test | priceless name-layout row yields `price: 0`                              |
+| developer    | `free`                      | default `false`                               | established test | priceless name-layout row yields `free: false`                           |
+| developer    | `summary`                   | optional                                      | pinned reference | absent optional summary remains undefined                                |
+| developer    | `scoreText`                 | optional                                      | pinned reference | unrated apps may omit score metadata                                     |
+| developer    | `score`                     | optional                                      | pinned reference | unrated apps may omit score metadata                                     |
+| similar      | `title`                     | required                                      | recorded fixture | similar fixture populates item titles                                    |
+| similar      | `appId`                     | required                                      | recorded fixture | similar fixture populates app ids                                        |
+| similar      | `url`                       | required                                      | recorded fixture | similar fixture populates item links                                     |
+| similar      | `icon`                      | required                                      | recorded fixture | similar fixture populates item icons                                     |
+| similar      | `developer`                 | required                                      | recorded fixture | similar fixture populates developer names                                |
+| similar      | `currency`                  | optional                                      | pinned reference | absent optional currency remains undefined                               |
+| similar      | `price`                     | default `0`                                   | established test | priceless similar row yields `price: 0`                                  |
+| similar      | `free`                      | default `false`                               | established test | priceless similar row yields `free: false`                               |
+| similar      | `summary`                   | optional                                      | pinned reference | absent optional summary remains undefined                                |
+| similar      | `scoreText`                 | optional                                      | pinned reference | unrated apps may omit score metadata                                     |
+| similar      | `score`                     | optional                                      | pinned reference | unrated apps may omit score metadata                                     |
+| reviews      | `id`                        | required                                      | recorded fixture | every recorded review carries an id                                      |
+| reviews      | `userName`                  | required                                      | recorded fixture | every recorded review carries a user name                                |
+| reviews      | `userImage`                 | optional                                      | pinned reference | absent optional user image remains undefined                             |
+| reviews      | `date`                      | required                                      | recorded fixture | every recorded review carries a date tuple                               |
+| reviews      | `score`                     | required                                      | recorded fixture | every recorded review carries a score                                    |
+| reviews      | `title`                     | required                                      | pinned reference | title derives from the required review id source                         |
+| reviews      | `text`                      | optional                                      | pinned reference | reviews may omit text                                                    |
+| reviews      | `replyDate`                 | optional                                      | pinned reference | reviews without a developer reply omit its date                          |
+| reviews      | `replyText`                 | optional                                      | pinned reference | reviews without a developer reply omit its text                          |
+| reviews      | `version`                   | optional                                      | pinned reference | reviews may omit the app version                                         |
+| reviews      | `thumbsUp`                  | optional                                      | pinned reference | absent optional vote count remains undefined                             |
+| reviews      | `criterias`                 | default `[]`                                  | recorded fixture | reviews without criteria retain an empty criteria list                   |
+| dataSafety   | `sharedData`                | default `[]`                                  | established test | missing-app response yields an empty report                              |
+| dataSafety   | `collectedData`             | default `[]`                                  | established test | missing-app response yields an empty report                              |
+| dataSafety   | `securityPractices`         | default `[]`                                  | established test | missing-app response yields an empty report                              |
+| dataSafety   | `privacyPolicyUrl`          | optional                                      | established test | missing-app response omits the policy link                               |
 
 ## Reading the evidence column
 

--- a/e2e/edgeCases.e2e.test.ts
+++ b/e2e/edgeCases.e2e.test.ts
@@ -16,6 +16,16 @@ const ZERO_DECIMAL_PAID = 'com.mojang.minecraftpe';
 const RTL_STOREFRONT = 'com.whatsapp';
 const IN_APP_PURCHASES = 'com.roblox.client';
 
+const PREREGISTRATION_CANDIDATES = [
+  'com.ironhidegames.android.kingdomrush6.genesis',
+  'com.devolver.reignsbeyond',
+  'com.com2usholdings.agwiv.android.google.global.normal',
+  'com.Pocketpair.NeverGrave',
+  'com.wanda.jojo.gp.global',
+  'com.bytro.warhammer40ksupremacy',
+  'com.dreamloft.grumpykingdom',
+];
+
 const EMPTY_HISTOGRAM = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
 const YEAR_2000_MS = 946684800000;
 const YEAR_2100_MS = 4102444800000;
@@ -231,6 +241,93 @@ liveDescribe('commercial model edges live contract', () => {
     expect(result.price).toBeGreaterThan(0);
     expect(Number.isInteger(result.price)).toBe(true);
     expect(result.priceText.length).toBeGreaterThan(0);
+  });
+});
+
+liveDescribe('preregistration listings live contract', () => {
+  it('resolves every preregistration candidate without a spec failure', async () => {
+    const events: IntegrityEvent[] = [];
+    const results = await Promise.all(
+      PREREGISTRATION_CANDIDATES.map((appId) =>
+        liveClient.app({ appId, onIntegrityEvent: (event) => events.push(event) }),
+      ),
+    );
+
+    for (const result of results) {
+      expect(result.title.length).toBeGreaterThan(0);
+      expect(result.description.length).toBeGreaterThan(0);
+      expect(result.screenshots.length).toBeGreaterThan(0);
+      expect(typeof result.preregister).toBe('boolean');
+      expect(typeof result.earlyAccessEnabled).toBe('boolean');
+    }
+    for (const event of events) {
+      expect(event.reason).toBe('optional-section-parse');
+      expect(event.context).toBe('app comments');
+    }
+  });
+
+  it('reports an offerless listing for the candidates still in preregistration', async () => {
+    const results = await Promise.all(
+      PREREGISTRATION_CANDIDATES.map((appId) => liveClient.app({ appId })),
+    );
+    const preregistering = results.filter((result) => result.preregister);
+
+    expect(preregistering.length).toBeGreaterThan(0);
+
+    for (const result of preregistering) {
+      expect(result.price).toBe(0);
+      expect(result.free).toBe(false);
+      expect(result.priceText).toBe('Free');
+      expect(result.currency).toBeUndefined();
+      expect(result.originalPrice).toBeUndefined();
+      expect(result.installs).toBeUndefined();
+      expect(result.minInstalls).toBeUndefined();
+      expect(result.score).toBeUndefined();
+      expect(result.ratings).toBeUndefined();
+      expect(result.histogram).toEqual(EMPTY_HISTOGRAM);
+      expect(result.released).toBeUndefined();
+    }
+  });
+
+  it('covers early access among the preregistration candidates', async () => {
+    const results = await Promise.all(
+      PREREGISTRATION_CANDIDATES.map((appId) => liveClient.app({ appId })),
+    );
+    const earlyAccess = results.filter((result) => result.earlyAccessEnabled);
+
+    expect(earlyAccess.length).toBeGreaterThan(0);
+
+    for (const result of earlyAccess) {
+      expect(result.preregister).toBe(true);
+      expect(result.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('serves reports and neighbours for a preregistration listing', async () => {
+    const appId = PREREGISTRATION_CANDIDATES[0] ?? '';
+    const [permissions, safety, similar, reviews] = await Promise.all([
+      liveClient.permissions({ appId }),
+      liveClient.dataSafety({ appId }),
+      liveClient.similar({ appId }),
+      liveClient.reviews({ appId, num: 5 }),
+    ]);
+
+    expect(permissions.length).toBeGreaterThan(0);
+    expect(safety.privacyPolicyUrl?.length).toBeGreaterThan(0);
+    expect(similar.length).toBeGreaterThan(0);
+    expect(reviews.data).toEqual([]);
+    expect(reviews.nextPaginationToken).toBeNull();
+  });
+
+  it('keeps a preregistration match in a search page instead of failing it', async () => {
+    const results = await liveClient.search({ term: 'Reigns Beyond', num: 20 });
+
+    expect(results.length).toBeGreaterThan(0);
+    for (const item of results) {
+      expect(typeof item.free).toBe('boolean');
+      expect(Number.isFinite(item.price)).toBe(true);
+    }
+    expect(results.some((item) => item.appId === 'com.devolver.reignsbeyond')).toBe(true);
   });
 });
 

--- a/src/features/app/app.test.ts
+++ b/src/features/app/app.test.ts
@@ -258,6 +258,48 @@ describe('app', () => {
     expect(enabled.isAvailableInPlayPass).toBe(true);
   });
 
+  it('parses a preregistration listing that carries no offer node', async () => {
+    const data = parseScriptData(translateHtml);
+    const ds5 = data.blocks['ds:5'] as unknown[];
+    const details = (ds5[1] as unknown[])[2] as unknown[];
+    details[57] = null;
+    details[18] = [1];
+    const preregisterHtml = buildScriptData('ds:5', ds5);
+
+    const result = await app({
+      appId: 'com.google.android.apps.translate',
+      requestOptions: { fetchImpl: fetchReturning(preregisterHtml) },
+    });
+
+    expect(result.preregister).toBe(true);
+    expect(result.earlyAccessEnabled).toBe(false);
+    expect(result.price).toBe(0);
+    expect(result.free).toBe(false);
+    expect(result.priceText).toBe('Free');
+    expect(result.currency).toBeUndefined();
+    expect(result.originalPrice).toBeUndefined();
+    expect(result.discountEndDate).toBeUndefined();
+  });
+
+  it('reports early access alongside preregistration when the offer node is absent', async () => {
+    const data = parseScriptData(translateHtml);
+    const ds5 = data.blocks['ds:5'] as unknown[];
+    const details = (ds5[1] as unknown[])[2] as unknown[];
+    details[57] = null;
+    details[18] = [1, null, 'early-access'];
+    const earlyAccessHtml = buildScriptData('ds:5', ds5);
+
+    const result = await app({
+      appId: 'com.google.android.apps.translate',
+      requestOptions: { fetchImpl: fetchReturning(earlyAccessHtml) },
+    });
+
+    expect(result.preregister).toBe(true);
+    expect(result.earlyAccessEnabled).toBe(true);
+    expect(result.free).toBe(false);
+    expect(result.priceText).toBe('Free');
+  });
+
   it('exposes the original price when a discount is active', async () => {
     const data = parseScriptData(minecraftHtml);
     const ds5 = data.blocks['ds:5'] as unknown[];

--- a/src/features/app/specs.ts
+++ b/src/features/app/specs.ts
@@ -22,6 +22,8 @@ const REQUIRED = required();
 const OPTIONAL = optional();
 const DEFAULT_FALSE = defaulted(() => false);
 const DEFAULT_VARY = defaulted(() => 'VARY');
+const DEFAULT_PRICE = defaulted(() => 0);
+const DEFAULT_PRICE_TEXT = defaulted(() => 'Free');
 
 export const APP_DETAILS_RPC_ID = 'Ws7gDc';
 
@@ -107,7 +109,7 @@ export const appSpecs = {
   },
   price: {
     paths: [[1, 2, 57, 0, 0, 0, 0, 1, 0, 0]],
-    missing: REQUIRED,
+    missing: DEFAULT_PRICE,
     schema: shape.price,
     transform: microsToUnits,
   },
@@ -126,7 +128,7 @@ export const appSpecs = {
   },
   free: {
     paths: [[1, 2, 57, 0, 0, 0, 0, 1, 0, 0]],
-    missing: REQUIRED,
+    missing: DEFAULT_FALSE,
     schema: shape.free,
     transform: (value) => value === 0,
   },
@@ -137,7 +139,7 @@ export const appSpecs = {
   },
   priceText: {
     paths: [[1, 2, 57, 0, 0, 0, 0, 1, 0, 2]],
-    missing: REQUIRED,
+    missing: DEFAULT_PRICE_TEXT,
     schema: shape.priceText,
     transform: priceText,
   },

--- a/src/features/search/search.test.ts
+++ b/src/features/search/search.test.ts
@@ -365,6 +365,12 @@ const paidCoreData = (id: string): unknown[] => {
   return core;
 };
 
+const preregisterCoreData = (id: string): unknown[] => {
+  const core = coreData(id);
+  core[8] = null;
+  return core;
+};
+
 const mixedPageHtml = (freeIds: string[], paidIds: string[]): string => {
   const apps = [...freeIds.map((id) => [coreData(id)]), ...paidIds.map((id) => [paidCoreData(id)])];
   const section: unknown[] = [];
@@ -409,6 +415,39 @@ describe('search price filtering', () => {
     })) as SearchResult[];
 
     expect(results.map((item) => item.appId).sort()).toEqual(['free1', 'paid1']);
+  });
+
+  it('keeps a preregistration row without an offer node instead of failing the page', async () => {
+    const apps = [[coreData('free1')], [preregisterCoreData('prereg1')], [paidCoreData('paid1')]];
+    const section: unknown[] = [];
+    section[22] = [apps];
+    const html = buildScriptData('ds:4', [[null, [section]]]);
+
+    const results = (await search({
+      term: 'panda',
+      requestOptions: { fetchImpl: fetchReturning(html) },
+    })) as SearchResult[];
+
+    expect(results.map((item) => item.appId)).toEqual(['free1', 'prereg1', 'paid1']);
+    const preregister = results.find((item) => item.appId === 'prereg1');
+    expect(preregister?.price).toBe(0);
+    expect(preregister?.free).toBe(false);
+    expect(preregister?.currency).toBeUndefined();
+  });
+
+  it('excludes an offerless preregistration row from a free price filter', async () => {
+    const apps = [[coreData('free1')], [preregisterCoreData('prereg1')]];
+    const section: unknown[] = [];
+    section[22] = [apps];
+    const html = buildScriptData('ds:4', [[null, [section]]]);
+
+    const results = (await search({
+      term: 'panda',
+      price: 'free',
+      requestOptions: { fetchImpl: fetchReturning(html) },
+    })) as SearchResult[];
+
+    expect(results.map((item) => item.appId)).toEqual(['free1']);
   });
 });
 

--- a/src/features/search/specs.ts
+++ b/src/features/search/specs.ts
@@ -10,6 +10,8 @@ import * as z from 'zod/mini';
 const shape = searchResultSchema.shape;
 const REQUIRED = required();
 const OPTIONAL = optional();
+const DEFAULT_PRICE = defaulted(() => 0);
+const DEFAULT_NOT_FREE = defaulted(() => false);
 
 export type PriceFilter = 'all' | 'free' | 'paid';
 export const SEARCH_RPC_ID = 'lGYRle';
@@ -51,13 +53,13 @@ export const searchItemSpecs = {
   currency: { paths: [[0, 8, 1, 0, 1]], missing: OPTIONAL, schema: shape.currency },
   price: {
     paths: [[0, 8, 1, 0, 0]],
-    missing: REQUIRED,
+    missing: DEFAULT_PRICE,
     schema: shape.price,
     transform: microsToUnits,
   },
   free: {
     paths: [[0, 8, 1, 0, 0]],
-    missing: REQUIRED,
+    missing: DEFAULT_NOT_FREE,
     schema: shape.free,
     transform: isFreeMicros,
   },
@@ -75,11 +77,16 @@ export const searchPageItemSpecs = {
   currency: { paths: [[8, 1, 0, 1]], missing: OPTIONAL, schema: shape.currency },
   price: {
     paths: [[8, 1, 0, 0]],
-    missing: REQUIRED,
+    missing: DEFAULT_PRICE,
     schema: shape.price,
     transform: microsToUnits,
   },
-  free: { paths: [[8, 1, 0, 0]], missing: REQUIRED, schema: shape.free, transform: isFreeMicros },
+  free: {
+    paths: [[8, 1, 0, 0]],
+    missing: DEFAULT_NOT_FREE,
+    schema: shape.free,
+    transform: isFreeMicros,
+  },
   summary: { paths: [[13, 1]], missing: OPTIONAL, schema: shape.summary },
   scoreText: { paths: [[4, 0]], missing: OPTIONAL, schema: shape.scoreText },
   score: { paths: [[4, 1]], missing: OPTIONAL, schema: shape.score },
@@ -105,13 +112,13 @@ export const exactMatchSpecs = {
   currency: { paths: [[17, 0, 2, 0, 1, 0, 1]], missing: OPTIONAL, schema: shape.currency },
   price: {
     paths: [[17, 0, 2, 0, 1, 0, 0]],
-    missing: defaulted(() => 0),
+    missing: DEFAULT_PRICE,
     schema: shape.price,
     transform: microsToUnits,
   },
   free: {
     paths: [[17, 0, 2, 0, 1, 0, 0]],
-    missing: defaulted(() => false),
+    missing: DEFAULT_NOT_FREE,
     schema: shape.free,
     transform: isFreeMicros,
   },

--- a/test/scraperIntegrityHtml.test.ts
+++ b/test/scraperIntegrityHtml.test.ts
@@ -116,9 +116,23 @@ describe('response mutation helpers', () => {
 });
 
 describe('app field mutations', () => {
-  it('rejects missing price and free sources without plausible defaults', async () => {
+  it('rejects a missing genre source without a plausible default', async () => {
+    const details = deletePath(appDetails(), appSpecs.genre.paths[0] ?? []);
+    await expectAppSpecFailure(replaceScriptBlockData(appHtml, 'ds:5', details), ['genre']);
+  });
+
+  it('treats a missing offer source as an unpriced listing rather than a failure', async () => {
     const details = deletePath(appDetails(), appSpecs.price.paths[0] ?? []);
-    await expectAppSpecFailure(replaceScriptBlockData(appHtml, 'ds:5', details), ['price', 'free']);
+    const events: IntegrityEvent[] = [];
+
+    const result = await appWithHtml(replaceScriptBlockData(appHtml, 'ds:5', details), (event) =>
+      events.push(event),
+    );
+
+    expect(result.price).toBe(0);
+    expect(result.free).toBe(false);
+    expect(result.priceText).toBe('Free');
+    expect(events).toEqual([]);
   });
 
   it('treats a missing availability source as unavailable rather than a failure', async () => {


### PR DESCRIPTION
## Summary

Google Play serves no offer node for a listing that has not been released yet. `app()` read
`price`, `free` and `priceText` as required at `[1, 2, 57, 0, 0, 0, 0, 1, 0, ...]`, and
`search()` read `price` and `free` as required at `[0, 8, 1, 0, 0]`, so every preregistration
listing raised a `SpecError` instead of parsing.

Measured against the
[pre-registration games collection](https://play.google.com/store/apps/collection/promotion_3000000d51_pre_registration_games),
sampling all 20 ids on the page plus 7 resolved by title:

| Surface    | Before                                        | After                        |
| ---------- | --------------------------------------------- | ---------------------------- |
| `app()`    | 5 of 27 parsed, 22 threw `SpecError`          | 27 of 27 parse               |
| `search()` | 8 of 10 probe terms parsed, 2 threw           | 10 of 10 parse               |

`search()` failed hardest: one preregistration row anywhere in a 20 result page threw for the
whole call, so `search({ term: 'Reigns Beyond' })` returned nothing at all.

The raw payload distinguishes the two cases cleanly, which is what makes this a real absence
rather than a free app:

```
released paid   [0,8] = [null,[[2990000,"USD","$2.99"]], ...]
released free   [0,8] = [null,[[0,"USD",""]], ...]
preregistration [0,8] = null
```

## What changed

`price`, `free` and `priceText` now fall back to `0`, `false` and `Free` when the offer node
is absent, which is what `list()`, `developer()`, `similar()` and the search exact match branch
already did for the same shape. `preregister` is the field to read before trusting any price
value; it stays authoritative and is now actually reachable.

`free: false` was chosen over `free: true` so that a single rule covers every micros based
surface. The practical effect is that a `price: 'free'` filter does not match an unreleased
app, which is the safer default when the release price is unknown.

## Side effects

`preregister` and `earlyAccessEnabled` were parsed correctly all along but were unreachable in
practice, because `app()` threw before it could return them. Both are now exercised against
live data for the first time: `preregister: true` on 22 sampled apps, `earlyAccessEnabled: true`
on 4.

The `docs/FIELD_ABSENCE_AUDIT.md` rows for these five fields justified `required` with
"price micros present in all app fixtures". That was true and misleading, since every recorded
fixture is a released app. The rows now cite the live probe instead.

## Notes for review

- `test/scraperIntegrityHtml.test.ts` had a test asserting the old behavior, named "rejects
  missing price and free sources without plausible defaults". It is rewritten to assert the new
  defaults, and a replacement mutation test covers `genre`, which is still genuinely required,
  so the `expectAppSpecFailure` helper keeps its coverage.
- Preregistration apps are transient by nature. The e2e test requires at least one candidate in
  `PREREGISTRATION_CANDIDATES` to still be preregistering, so it fails loudly rather than
  silently degrading into a no-op once those titles ship. That list needs refreshing when they
  launch.
- The other surfaces needed no changes. `permissions()`, `dataSafety()`, `similar()`,
  `reviews()` and `availability()` were verified against all 27 apps and already degrade
  correctly, including the `app comments: skipped unparsable fallback ds:8` integrity event that
  an offerless listing legitimately emits.

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test:coverage` (624 unit tests, 99.51% statements) and
`pnpm build` pass. `pnpm test:e2e` passes with 144 live tests, including the 5 new
preregistration contract tests.

## Checklist

- [x] Commits follow Conventional Commits (`type(scope): subject`, imperative, lowercase, max 72 characters)
- [x] Branch name follows the conventional branch spec (`feature/`, `bugfix/`, `chore/`, ...)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test:coverage` and `pnpm build` pass locally
- [x] New behavior is covered by unit tests against fixtures
- [x] Live behavior is covered by e2e tests in `e2e/` where applicable
- [x] No comments and no `console` calls in changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preregistration apps, including clear preregistration status and offerless pricing details.
  * Preregistration listings appear in general search results but are excluded from the “free” price filter.
  * Added examples and documentation for handling preregistration apps.

* **Bug Fixes**
  * Improved handling of missing pricing information, including consistent free and zero-price defaults.

* **Tests**
  * Added coverage for preregistration, early access, pricing, search, permissions, safety, reviews, and related app data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->