### PR TITLE
fix(e2e): stop pinning catalogue state in live contract tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Benchmarks report performance rather than gate it. Never narrow a declared selec
 - TypeScript strict mode, no `any`, no non null assertions, no type assertions in `src/`.
 - External data enters as `unknown` and leaves through a zod schema.
 - Every feature change ships with unit tests against recorded fixtures and live e2e tests in `e2e/`.
-- Live e2e assertions must stay true whatever Google serves today. Assert shape, cross field consistency, and self anchoring counts, never third party catalogue state such as how many similar apps a listing has or whether an app still has no reviews. Two kinds of assertion are allowed to detect external change, regime tripwires and maintained anchor pools, and each one has to be registered in the runbook first. The rules, the exceptions, and the shared invariant helpers are described in [docs/RUNBOOK.md](docs/RUNBOOK.md#live-contract-assertion-rules).
+- Live e2e assertions must stay true whatever Google serves today. Assert shape, cross-field consistency, and self-anchoring counts, never third-party catalogue state such as how many similar apps a listing has or whether an app still has no reviews. Two kinds of assertion are allowed to detect external change, regime tripwires and maintained anchor pools, and each one has to be registered in the runbook first. The rules, the exceptions, and the shared invariant helpers are described in [docs/RUNBOOK.md](docs/RUNBOOK.md#live-contract-assertion-rules).
 - Versioning, changelog, and npm publishing are automated with Release Please. Do not bump versions or edit the changelog by hand.
 
 ## Fixing a broken field

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ Benchmarks report performance rather than gate it. Never narrow a declared selec
 - TypeScript strict mode, no `any`, no non null assertions, no type assertions in `src/`.
 - External data enters as `unknown` and leaves through a zod schema.
 - Every feature change ships with unit tests against recorded fixtures and live e2e tests in `e2e/`.
+- Live e2e assertions must stay true whatever Google serves today. Assert shape, cross field consistency, and self anchoring counts, never third party catalogue state such as how many similar apps a listing has or whether an app still has no reviews. The rules and the shared invariant helpers are described in [docs/RUNBOOK.md](docs/RUNBOOK.md#live-contract-assertion-rules).
 - Versioning, changelog, and npm publishing are automated with Release Please. Do not bump versions or edit the changelog by hand.
 
 ## Fixing a broken field

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Benchmarks report performance rather than gate it. Never narrow a declared selec
 - TypeScript strict mode, no `any`, no non null assertions, no type assertions in `src/`.
 - External data enters as `unknown` and leaves through a zod schema.
 - Every feature change ships with unit tests against recorded fixtures and live e2e tests in `e2e/`.
-- Live e2e assertions must stay true whatever Google serves today. Assert shape, cross field consistency, and self anchoring counts, never third party catalogue state such as how many similar apps a listing has or whether an app still has no reviews. The rules and the shared invariant helpers are described in [docs/RUNBOOK.md](docs/RUNBOOK.md#live-contract-assertion-rules).
+- Live e2e assertions must stay true whatever Google serves today. Assert shape, cross field consistency, and self anchoring counts, never third party catalogue state such as how many similar apps a listing has or whether an app still has no reviews. Two kinds of assertion are allowed to detect external change, regime tripwires and maintained anchor pools, and each one has to be registered in the runbook first. The rules, the exceptions, and the shared invariant helpers are described in [docs/RUNBOOK.md](docs/RUNBOOK.md#live-contract-assertion-rules).
 - Versioning, changelog, and npm publishing are automated with Release Please. Do not bump versions or edit the changelog by hand.
 
 ## Fixing a broken field

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -71,14 +71,14 @@ The other integrity reasons have narrower responses:
 ## Live contract assertion rules
 
 The scheduled suite exists to catch scraper breakage, not catalogue movement. An
-assertion that fails because Google reshuffled its catalogue files a false
+assertion that fails because Google reshuffled its catalogue creates a false
 `contract-breakage` issue and trains everyone to ignore the signal. By default
 an assertion under `e2e/` must therefore stay true no matter what Google serves
 today, which leaves four ordinary kinds:
 
 1. **Shape.** A field exists with the right type, a url resolves to the store
    origin, an icon is served over https.
-2. **Cross field consistency.** Two fields that come from _different_ page
+2. **Cross-field consistency.** Two fields that come from _different_ page
    nodes have to agree: `free` against `price` and `currency`, `score` against
    `scoreText`, `installs` against `minInstalls`, the histogram against the
    rating count. These are the sharpest breakage detectors in the suite because
@@ -86,7 +86,7 @@ today, which leaves four ordinary kinds:
    never does. Two fields parsed from the same node are not an invariant, they
    are a tautology: `offersIAP` and `IAPRange` both read `[1, 2, 19, 0]`, so
    only the shape of `IAPRange` is worth asserting.
-3. **Self anchoring.** The assertion derives its expectation from the same
+3. **Self-anchoring.** The assertion derives its expectation from the same
    response, for example `list({ num })` returning exactly `num` items or the
    search result set matching the first page it was built from.
 4. **Immutable fact.** A release date already in the past, an app id that
@@ -105,7 +105,7 @@ each one has to be registered in this runbook before it is written:
    anchor pools". These fail on purpose when Google changes, and their failure
    messages have to name the maintenance task rather than read as a parse break.
 
-Outside those two registered exceptions, never assert third party catalogue
+Outside those two registered exceptions, never assert third-party catalogue
 state. Concretely, do not pin how many apps Google recommends for a listing,
 whether a specific app currently has zero reviews or zero ratings, whether a
 category is currently empty, whether a game is still in preregistration, or
@@ -129,7 +129,7 @@ that coverage moved, without the run failing over it.
 ### Shared invariants
 
 `e2e/contracts.ts` holds the invariant helpers. Reach for them before writing a
-bespoke loop of assertions, and add to them when a new cross field agreement
+bespoke loop of assertions, and add to them when a new cross-field agreement
 turns up:
 
 - `expectAppItemContract` and `expectAppItemsContract` for search, list, similar
@@ -165,7 +165,7 @@ A state that needs a live true branch belongs on a controlled anchor whenever an
 owned listing can reach it. `com.adex77.WhereAmI` carries `adSupported`,
 `offersIAP`, and every optional media field (`video`, `videoImage`, `IAPRange`,
 `released`, `contentRatingDescription`, `recentChanges`), so those gates sit on
-it directly rather than on a pool of third party apps.
+it directly rather than on a pool of third-party apps.
 
 One state has no owned anchor, because Play Pass membership is granted by Google
 and cannot be arranged for a maintainer's own app:

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -68,6 +68,96 @@ The other integrity reasons have narrower responses:
   repeated token, and inspect the pagination response before changing token
   extraction. Tokens must never be written to logs or event messages.
 
+## Live contract assertion rules
+
+The scheduled suite exists to catch scraper breakage, not catalogue movement. An
+assertion that fails because Google reshuffled its catalogue files a false
+`contract-breakage` issue and trains everyone to ignore the signal. Every
+assertion under `e2e/` must therefore stay true no matter what Google serves
+today, which leaves six legitimate kinds:
+
+1. **Shape.** A field exists with the right type, a url resolves to the store
+   origin, an icon is served over https.
+2. **Cross field consistency.** Two fields that come from the same page node
+   have to agree: `free` against `price` and `currency`, `score` against
+   `scoreText`, `installs` against `minInstalls`, the histogram against the
+   rating count, `offersIAP` against `IAPRange`. These are the sharpest
+   breakage detectors in the suite because a drifted path breaks the agreement
+   immediately while catalogue movement never does.
+3. **Self anchoring.** The assertion derives its expectation from the same
+   response, for example `list({ num })` returning exactly `num` items or the
+   search result set matching the first page it was built from.
+4. **Immutable fact.** A release date already in the past, an app id that
+   resolves forever, a category id that is part of the taxonomy constant.
+5. **Controlled anchor.** A listing this repository's maintainer owns, such as
+   `com.adex77.WhereAmI` or the `Adex77` developer id. A change there is a
+   deliberate change, not a surprise.
+6. **Regime tripwire.** A documented probe of Google's serving behaviour, listed
+   under "Pagination tripwires" below.
+
+Never assert third party catalogue state. Concretely, do not pin how many apps
+Google recommends for a listing, whether a specific app currently has zero
+reviews or zero ratings, whether a category is currently empty, whether a title
+is currently in Play Pass, whether a game is still in preregistration, or where
+an app ranks for a search term. Assert the invariant that holds in either state
+and let the test follow the catalogue.
+
+When a state still deserves live coverage, branch on what the page actually
+reports instead of assuming a state:
+
+```ts
+if (listing.ratings === undefined) {
+  expect(page.data).toEqual([]);
+  return;
+}
+expect(page.data.length).toBeGreaterThan(0);
+```
+
+Report which branch ran with vitest's `annotate` so a reader of the run can see
+that coverage moved, without the run failing over it.
+
+### Shared invariants
+
+`e2e/contracts.ts` holds the invariant helpers. Reach for them before writing a
+bespoke loop of assertions, and add to them when a new cross field agreement
+turns up:
+
+- `expectAppItemContract` and `expectAppItemsContract` for search, list, similar
+  and developer items.
+- `expectListingContract` for a full `app()` result, which composes the offer,
+  rating, histogram, installs, purchase and release state invariants.
+- `expectReviewContract` and `expectReviewsContract` for review pages.
+
+Two tolerances in that module are measured, not guessed. The histogram tracks
+the rating count to within `max(10, 1% of ratings)`, measured across listings
+from 31 to 242 million ratings. `scoreText` is the score rounded to one decimal,
+so it agrees to within 0.051 once the locale decimal comma is normalized.
+Re-measure with `pnpm coverage:live` and a scratch probe before moving either.
+
+### Maintained anchor pools
+
+Three assertions still need at least one anchor to be in a particular state, so
+they run against a pool instead of a single listing and fail only when the whole
+pool has drifted:
+
+- `PLAY_PASS_CANDIDATES` in `e2e/edgeCases.e2e.test.ts` must keep one title in
+  Play Pass.
+- `COMMERCIAL_MODEL_BASKET` in `e2e/app.e2e.test.ts` must keep one ad supported
+  listing and one with in app purchases.
+- `RICH_MEDIA_BASKET` in `e2e/app.e2e.test.ts` must keep one listing filling
+  each of the optional media fields.
+
+Their failure messages say "re-anchor the pool". That is a maintenance task, not
+a scraper break: replace the drifted ids with listings that are in the wanted
+state and commit as `test(e2e): re-anchor the <name> pool`. Never delete the
+pool assertion instead, since it is the only live gate on that branch.
+
+`PREREGISTRATION_CANDIDATES` deliberately carries no such gate. Preregistration
+listings launch, so the suite asserts the state conditional invariants on each
+candidate and annotates how many are still unlaunched. Refresh the list when the
+annotation reports zero, and note that both branches of the parser are covered
+offline in `src/features/app/app.test.ts`.
+
 ## Pagination tripwires
 
 Two e2e tests pin the current Google Play serving regime instead of the code:
@@ -76,6 +166,13 @@ Two e2e tests pin the current Google Play serving regime instead of the code:
   `e2e/search.e2e.test.ts`
 - `confirms the numeric first page still requires a continuation` in
   `e2e/developer.e2e.test.ts`
+
+Three measured page sizes back the count assertions that surround them:
+`FIRST_PAGE_SIZE` (150 reviews) in `e2e/iterators.e2e.test.ts`,
+`SIMILAR_CLUSTER_PAGE_SIZE` (50 apps) in `e2e/similar.e2e.test.ts`, and
+`LIST_CEILING_FLOOR` (150 apps) in `e2e/list.e2e.test.ts`. Each one exists so
+that a count assertion proves a continuation was followed rather than pinning
+how large a catalogue is. Re-measure the page directly before changing one.
 
 A tripwire failure means Google changed the serving regime, not that the code
 broke. The count assertions in the surrounding suites rely on the premises these

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -72,35 +72,45 @@ The other integrity reasons have narrower responses:
 
 The scheduled suite exists to catch scraper breakage, not catalogue movement. An
 assertion that fails because Google reshuffled its catalogue files a false
-`contract-breakage` issue and trains everyone to ignore the signal. Every
-assertion under `e2e/` must therefore stay true no matter what Google serves
-today, which leaves six legitimate kinds:
+`contract-breakage` issue and trains everyone to ignore the signal. By default
+an assertion under `e2e/` must therefore stay true no matter what Google serves
+today, which leaves four ordinary kinds:
 
 1. **Shape.** A field exists with the right type, a url resolves to the store
    origin, an icon is served over https.
-2. **Cross field consistency.** Two fields that come from the same page node
-   have to agree: `free` against `price` and `currency`, `score` against
+2. **Cross field consistency.** Two fields that come from _different_ page
+   nodes have to agree: `free` against `price` and `currency`, `score` against
    `scoreText`, `installs` against `minInstalls`, the histogram against the
-   rating count, `offersIAP` against `IAPRange`. These are the sharpest
-   breakage detectors in the suite because a drifted path breaks the agreement
-   immediately while catalogue movement never does.
+   rating count. These are the sharpest breakage detectors in the suite because
+   a drifted path breaks the agreement immediately while catalogue movement
+   never does. Two fields parsed from the same node are not an invariant, they
+   are a tautology: `offersIAP` and `IAPRange` both read `[1, 2, 19, 0]`, so
+   only the shape of `IAPRange` is worth asserting.
 3. **Self anchoring.** The assertion derives its expectation from the same
    response, for example `list({ num })` returning exactly `num` items or the
    search result set matching the first page it was built from.
 4. **Immutable fact.** A release date already in the past, an app id that
    resolves forever, a category id that is part of the taxonomy constant.
+
+Two further kinds are deliberate exceptions that do detect external change, so
+each one has to be registered in this runbook before it is written:
+
 5. **Controlled anchor.** A listing this repository's maintainer owns, such as
    `com.adex77.WhereAmI` or the `Adex77` developer id. A change there is a
-   deliberate change, not a surprise.
-6. **Regime tripwire.** A documented probe of Google's serving behaviour, listed
-   under "Pagination tripwires" below.
+   deliberate change by the person reading the failure, not a surprise. Prefer
+   this over any pool whenever an owned listing can carry the state.
+6. **Regime tripwire and maintained anchor pool.** A documented probe of
+   Google's serving behaviour, listed under "Pagination tripwires", or a pool
+   that guards a state no owned listing can reach, listed under "Maintained
+   anchor pools". These fail on purpose when Google changes, and their failure
+   messages have to name the maintenance task rather than read as a parse break.
 
-Never assert third party catalogue state. Concretely, do not pin how many apps
-Google recommends for a listing, whether a specific app currently has zero
-reviews or zero ratings, whether a category is currently empty, whether a title
-is currently in Play Pass, whether a game is still in preregistration, or where
-an app ranks for a search term. Assert the invariant that holds in either state
-and let the test follow the catalogue.
+Outside those two registered exceptions, never assert third party catalogue
+state. Concretely, do not pin how many apps Google recommends for a listing,
+whether a specific app currently has zero reviews or zero ratings, whether a
+category is currently empty, whether a game is still in preregistration, or
+where an app ranks for a search term. Assert the invariant that holds in either
+state and let the test follow the catalogue.
 
 When a state still deserves live coverage, branch on what the page actually
 reports instead of assuming a state:
@@ -128,29 +138,47 @@ turns up:
   rating, histogram, installs, purchase and release state invariants.
 - `expectReviewContract` and `expectReviewsContract` for review pages.
 
-Two tolerances in that module are measured, not guessed. The histogram tracks
-the rating count to within `max(10, 1% of ratings)`, measured across listings
-from 31 to 242 million ratings. `scoreText` is the score rounded to one decimal,
-so it agrees to within 0.051 once the locale decimal comma is normalized.
-Re-measure with `pnpm coverage:live` and a scratch probe before moving either.
+Three thresholds in the suite are measured, not guessed, all on 2026-08-26:
+
+- The histogram tracks the rating count to within `max(10, 1% of ratings)`,
+  measured across listings from 31 to 242 million ratings.
+- `scoreText` is the score rounded to one decimal, so it agrees to within 0.051
+  once the locale decimal comma is normalized.
+- `DATA_RICH_COLLECTED_FLOOR` in `e2e/datasafety.e2e.test.ts` is 10 against 37
+  entries measured on `com.instagram.android`, so a partial parse of the
+  collected data section fails while an ordinary policy edit does not.
+
+Two localized formats decide whether a check runs at all. The install count
+comparison only runs when the string is plain grouped ASCII digits, so a
+storefront that abbreviates the tier (`10万+`) or uses Arabic-Indic digits skips
+the equality instead of comparing a value it cannot read. The `IAPRange` shape
+check accepts any Unicode decimal digit, because the Arabic storefront serves
+`‏١٢٫٩٩ ج.م.‏ - ‏١٢٬٢٤٩٫٩٩ ج.م.‏ لكل عنصر` and the Japanese one serves
+`￥50～￥57,800/アイテム`.
+
+Re-measure with `pnpm coverage:live` and a scratch probe before moving any of
+them.
 
 ### Maintained anchor pools
 
-Three assertions still need at least one anchor to be in a particular state, so
-they run against a pool instead of a single listing and fail only when the whole
-pool has drifted:
+A state that needs a live true branch belongs on a controlled anchor whenever an
+owned listing can reach it. `com.adex77.WhereAmI` carries `adSupported`,
+`offersIAP`, and every optional media field (`video`, `videoImage`, `IAPRange`,
+`released`, `contentRatingDescription`, `recentChanges`), so those gates sit on
+it directly rather than on a pool of third party apps.
+
+One state has no owned anchor, because Play Pass membership is granted by Google
+and cannot be arranged for a maintainer's own app:
 
 - `PLAY_PASS_CANDIDATES` in `e2e/edgeCases.e2e.test.ts` must keep one title in
-  Play Pass.
-- `COMMERCIAL_MODEL_BASKET` in `e2e/app.e2e.test.ts` must keep one ad supported
-  listing and one with in app purchases.
-- `RICH_MEDIA_BASKET` in `e2e/app.e2e.test.ts` must keep one listing filling
-  each of the optional media fields.
+  Play Pass. It runs against four titles and fails only when all four have left,
+  which is the only live gate on the `[1, 2, 62]` path.
 
-Their failure messages say "re-anchor the pool". That is a maintenance task, not
-a scraper break: replace the drifted ids with listings that are in the wanted
-state and commit as `test(e2e): re-anchor the <name> pool`. Never delete the
-pool assertion instead, since it is the only live gate on that branch.
+Its failure message says "re-anchor the pool". That is a maintenance task, not a
+scraper break: replace the drifted ids with listings that are in the wanted
+state and commit as `test(e2e): re-anchor the play pass pool`. Never delete the
+pool assertion instead, since dropping it leaves `isAvailableInPlayPass` with no
+live coverage of its true branch.
 
 `PREREGISTRATION_CANDIDATES` deliberately carries no such gate. Preregistration
 listings launch, so the suite asserts the state conditional invariants on each
@@ -178,12 +206,15 @@ Two e2e tests pin the current Google Play serving regime instead of the code:
 - `confirms the numeric first page still requires a continuation` in
   `e2e/developer.e2e.test.ts`
 
-Three measured page sizes back the count assertions that surround them:
+Three measured serving limits back the count assertions that surround them:
 `FIRST_PAGE_SIZE` (150 reviews) in `e2e/iterators.e2e.test.ts`,
 `SIMILAR_CLUSTER_PAGE_SIZE` (50 apps) in `e2e/similar.e2e.test.ts`, and
-`LIST_CEILING_FLOOR` (150 apps) in `e2e/list.e2e.test.ts`. Each one exists so
+`LIST_MAX_ITEMS` (200 apps) in `e2e/list.e2e.test.ts`. The first two exist so
 that a count assertion proves a continuation was followed rather than pinning
-how large a catalogue is. Re-measure the page directly before changing one.
+how large a catalogue is. `LIST_MAX_ITEMS` is the hard ceiling `list` returns
+however large `num` gets, measured identical at `num` 200, 250 and 500 on
+2026-08-26, so the assertion is exact and moves only when Google moves the cap.
+Re-measure the page directly before changing one.
 
 A tripwire failure means Google changed the serving regime, not that the code
 broke. The count assertions in the surrounding suites rely on the premises these

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -154,9 +154,20 @@ pool assertion instead, since it is the only live gate on that branch.
 
 `PREREGISTRATION_CANDIDATES` deliberately carries no such gate. Preregistration
 listings launch, so the suite asserts the state conditional invariants on each
-candidate and annotates how many are still unlaunched. Refresh the list when the
-annotation reports zero, and note that both branches of the parser are covered
-offline in `src/features/app/app.test.ts`.
+candidate and annotates how many are still unlaunched. Both branches of the
+parser are covered offline in `src/features/app/app.test.ts`, so a fully
+launched pool costs live coverage but never fails the run.
+
+Refresh that list from Google's own preregistration shelf, which search does not
+surface:
+
+```
+https://play.google.com/store/apps/collection/promotion_3000000d51_pre_registration_games?hl=en&gl=us
+```
+
+Scrape the `id=` parameters out of that page, confirm `preregister` on a handful
+with `app()`, and commit the replacements as
+`test(e2e): refresh the preregistration candidates`.
 
 ## Pagination tripwires
 

--- a/e2e/app.e2e.test.ts
+++ b/e2e/app.e2e.test.ts
@@ -104,21 +104,15 @@ liveDescribe('app live contract', () => {
     expect(result.screenshots.length).toBeGreaterThanOrEqual(5);
   });
 
-  it('fills every optional media field on the maintained listing', async () => {
-    const result = await liveClient.app({ appId: GEO_GAME });
-
-    expectListingContract(result, 'maintained media listing');
-    expectFieldFilledSomewhere('app optional media', [asRecord(result)], OPTIONAL_MEDIA_FIELDS);
-  });
-
-  it('resolves rich third party listings without a spec failure', async () => {
+  it('fills every optional media field somewhere across the maintained basket', async () => {
     const listings = await Promise.all(
-      RICH_MEDIA_LISTINGS.map((appId) => liveClient.app({ appId })),
+      [GEO_GAME, ...RICH_MEDIA_LISTINGS].map((appId) => liveClient.app({ appId })),
     );
 
     for (const listing of listings) {
       expectListingContract(listing, 'rich media listing');
     }
+    expectFieldFilledSomewhere('app optional media', listings.map(asRecord), OPTIONAL_MEDIA_FIELDS);
   });
 
   it('reports the free with ads and purchases commercial model', async () => {

--- a/e2e/app.e2e.test.ts
+++ b/e2e/app.e2e.test.ts
@@ -24,9 +24,9 @@ const TRANSLATE_STABLE_FIELDS = [
   'contentRating',
 ] as const;
 
-const RICH_MEDIA_BASKET = [MINECRAFT, 'com.king.candycrushsaga', 'com.roblox.client'];
+const RICH_MEDIA_LISTINGS = [MINECRAFT, 'com.king.candycrushsaga', 'com.roblox.client'];
 
-const RICH_MEDIA_FIELDS = [
+const OPTIONAL_MEDIA_FIELDS = [
   'video',
   'videoImage',
   'IAPRange',
@@ -34,8 +34,6 @@ const RICH_MEDIA_FIELDS = [
   'contentRatingDescription',
   'recentChanges',
 ] as const;
-
-const COMMERCIAL_MODEL_BASKET = ['com.king.candycrushsaga', GEO_GAME, 'com.google.android.youtube'];
 
 function asRecord(listing: App): Record<string, unknown> {
   return listing;
@@ -106,36 +104,34 @@ liveDescribe('app live contract', () => {
     expect(result.screenshots.length).toBeGreaterThanOrEqual(5);
   });
 
-  it('fills media and purchase fields across rich listings', async () => {
-    const listings = await Promise.all(RICH_MEDIA_BASKET.map((appId) => liveClient.app({ appId })));
+  it('fills every optional media field on the maintained listing', async () => {
+    const result = await liveClient.app({ appId: GEO_GAME });
+
+    expectListingContract(result, 'maintained media listing');
+    expectFieldFilledSomewhere('app optional media', [asRecord(result)], OPTIONAL_MEDIA_FIELDS);
+  });
+
+  it('resolves rich third party listings without a spec failure', async () => {
+    const listings = await Promise.all(
+      RICH_MEDIA_LISTINGS.map((appId) => liveClient.app({ appId })),
+    );
 
     for (const listing of listings) {
       expectListingContract(listing, 'rich media listing');
     }
-    expectFieldFilledSomewhere('app rich media', listings.map(asRecord), RICH_MEDIA_FIELDS);
   });
 
   it('reports the free with ads and purchases commercial model', async () => {
-    const listings = await Promise.all(
-      COMMERCIAL_MODEL_BASKET.map((appId) => liveClient.app({ appId })),
-    );
+    const result = await liveClient.app({ appId: GEO_GAME });
 
-    for (const listing of listings) {
-      expectListingContract(listing, 'commercial model listing');
-      expect(listing.free).toBe(true);
-      expect(listing.price).toBe(0);
-      expect(listing.preregister).toBe(false);
-      expect(listing.available).toBe(true);
-    }
-
-    expect(
-      listings.some((listing) => listing.adSupported),
-      'no commercial model anchor reports ad support, re-anchor the basket',
-    ).toBe(true);
-    expect(
-      listings.some((listing) => listing.offersIAP === true),
-      'no commercial model anchor reports in app purchases, re-anchor the basket',
-    ).toBe(true);
+    expectListingContract(result, 'commercial model listing');
+    expect(result.free).toBe(true);
+    expect(result.price).toBe(0);
+    expect(result.preregister).toBe(false);
+    expect(result.available).toBe(true);
+    expect(result.adSupported).toBe(true);
+    expect(result.offersIAP).toBe(true);
+    expect(result.IAPRange?.trim().length).toBeGreaterThan(0);
   });
 
   it('localizes the paid price into the storefront currency', async () => {

--- a/e2e/app.e2e.test.ts
+++ b/e2e/app.e2e.test.ts
@@ -1,6 +1,11 @@
 import { expect, it } from 'vitest';
-import { NotFoundError, type IntegrityEvent } from '../src/index.js';
-import { liveClient, liveDescribe } from './helpers.js';
+import { NotFoundError, type App, type IntegrityEvent } from '../src/index.js';
+import { expectListingContract } from './contracts.js';
+import { expectFieldFilledSomewhere, liveClient, liveDescribe } from './helpers.js';
+
+const TRANSLATE = 'com.google.android.apps.translate';
+const GEO_GAME = 'com.adex77.WhereAmI';
+const MINECRAFT = 'com.mojang.minecraftpe';
 
 const TRANSLATE_STABLE_FIELDS = [
   'summary',
@@ -17,87 +22,83 @@ const TRANSLATE_STABLE_FIELDS = [
   'privacyPolicy',
   'headerImage',
   'contentRating',
-  'recentChanges',
 ] as const;
 
-const MINECRAFT_RICH_FIELDS = [
+const RICH_MEDIA_BASKET = [MINECRAFT, 'com.king.candycrushsaga', 'com.roblox.client'];
+
+const RICH_MEDIA_FIELDS = [
   'video',
   'videoImage',
   'IAPRange',
   'released',
   'contentRatingDescription',
+  'recentChanges',
 ] as const;
+
+const COMMERCIAL_MODEL_BASKET = ['com.king.candycrushsaga', GEO_GAME, 'com.google.android.youtube'];
+
+function asRecord(listing: App): Record<string, unknown> {
+  return listing;
+}
 
 liveDescribe('app live contract', () => {
   it('returns details for a popular free app', async () => {
-    const appId = 'com.google.android.apps.translate';
     const events: IntegrityEvent[] = [];
     const result = await liveClient.app({
-      appId,
+      appId: TRANSLATE,
       onIntegrityEvent: (event) => events.push(event),
     });
 
-    expect(result.title.length).toBeGreaterThan(0);
-    expect(result.appId).toBe(appId);
+    expectListingContract(result, 'flagship listing');
+    expect(result.appId).toBe(TRANSLATE);
     expect(typeof result.score).toBe('number');
-    expect(result.score).toBeGreaterThanOrEqual(0);
-    expect(result.score).toBeLessThanOrEqual(5);
     expect(result.ratings).toBeGreaterThan(100000);
     expect(result.free).toBe(true);
     expect(events).toEqual([]);
   });
 
   it('returns details for a mobile geography game', async () => {
-    const appId = 'com.adex77.WhereAmI';
-    const result = await liveClient.app({ appId });
+    const result = await liveClient.app({ appId: GEO_GAME });
 
+    expectListingContract(result, 'geography game listing');
     expect(result.title).toBe('Where Am I? - GeoGuess Game');
-    expect(result.appId).toBe(appId);
+    expect(result.appId).toBe(GEO_GAME);
     expect(result.released).toBe('Jan 2, 2021');
-    expect(typeof result.score).toBe('number');
-    expect(result.score).toBeGreaterThanOrEqual(0);
-    expect(result.score).toBeLessThanOrEqual(5);
-    expect(result.maxInstalls).toBeGreaterThan(10000);
+    expect(result.developer).toBe('Adex77');
     expect(result.free).toBe(true);
   });
 
   it('returns details for a paid app', async () => {
-    const result = await liveClient.app({ appId: 'com.mojang.minecraftpe' });
+    const result = await liveClient.app({ appId: MINECRAFT });
 
-    expect(result.title.length).toBeGreaterThan(0);
-    expect(typeof result.score).toBe('number');
-    expect(result.score).toBeGreaterThanOrEqual(0);
-    expect(result.score).toBeLessThanOrEqual(5);
+    expectListingContract(result, 'paid listing');
     expect(result.free).toBe(false);
     expect(result.price).toBeGreaterThan(0);
+    expect(result.currency).toBe('USD');
   });
 
   it('returns categorized details for a social app', async () => {
     const result = await liveClient.app({ appId: 'com.instagram.android' });
 
+    expectListingContract(result, 'social listing');
     expect(result.title).toContain('Instagram');
     expect(result.genreId).toBe('SOCIAL');
     expect(result.categories.some((category) => category.id === 'SOCIAL')).toBe(true);
-    expect(typeof result.adSupported).toBe('boolean');
     expect(result.installs?.endsWith('+')).toBe(true);
   });
 
   it('localizes the geography game details for another language and country', async () => {
-    const result = await liveClient.app({
-      appId: 'com.adex77.WhereAmI',
-      lang: 'pl',
-      country: 'pl',
-    });
+    const result = await liveClient.app({ appId: GEO_GAME, lang: 'pl', country: 'pl' });
 
-    expect(result.appId).toBe('com.adex77.WhereAmI');
-    expect(result.title.length).toBeGreaterThan(0);
-    expect(result.description.length).toBeGreaterThan(0);
+    expectListingContract(result, 'localized geography game listing');
+    expect(result.appId).toBe(GEO_GAME);
+    expect(result.currency).toBe('PLN');
     expect(result.free).toBe(true);
   });
 
   it('fills every stable optional field for a flagship listing', async () => {
-    const result = await liveClient.app({ appId: 'com.google.android.apps.translate' });
-    const record = result as unknown as Record<string, unknown>;
+    const result = await liveClient.app({ appId: TRANSLATE });
+    const record = asRecord(result);
 
     for (const field of TRANSLATE_STABLE_FIELDS) {
       expect(record[field], field).toBeDefined();
@@ -105,34 +106,42 @@ liveDescribe('app live contract', () => {
     expect(result.screenshots.length).toBeGreaterThanOrEqual(5);
   });
 
-  it('fills media and purchase fields for a rich paid listing', async () => {
-    const result = await liveClient.app({ appId: 'com.mojang.minecraftpe' });
-    const record = result as unknown as Record<string, unknown>;
+  it('fills media and purchase fields across rich listings', async () => {
+    const listings = await Promise.all(RICH_MEDIA_BASKET.map((appId) => liveClient.app({ appId })));
 
-    for (const field of MINECRAFT_RICH_FIELDS) {
-      expect(record[field], field).toBeDefined();
+    for (const listing of listings) {
+      expectListingContract(listing, 'rich media listing');
     }
+    expectFieldFilledSomewhere('app rich media', listings.map(asRecord), RICH_MEDIA_FIELDS);
   });
 
   it('reports the free with ads and purchases commercial model', async () => {
-    const result = await liveClient.app({ appId: 'com.king.candycrushsaga' });
+    const listings = await Promise.all(
+      COMMERCIAL_MODEL_BASKET.map((appId) => liveClient.app({ appId })),
+    );
 
-    expect(result.free).toBe(true);
-    expect(result.price).toBe(0);
-    expect(result.offersIAP).toBe(true);
-    expect(result.IAPRange?.trim().length).toBeGreaterThan(0);
-    expect(result.adSupported).toBe(true);
-    expect(result.preregister).toBe(false);
-    expect(result.available).toBe(true);
+    for (const listing of listings) {
+      expectListingContract(listing, 'commercial model listing');
+      expect(listing.free).toBe(true);
+      expect(listing.price).toBe(0);
+      expect(listing.preregister).toBe(false);
+      expect(listing.available).toBe(true);
+    }
+
+    expect(
+      listings.some((listing) => listing.adSupported),
+      'no commercial model anchor reports ad support, re-anchor the basket',
+    ).toBe(true);
+    expect(
+      listings.some((listing) => listing.offersIAP === true),
+      'no commercial model anchor reports in app purchases, re-anchor the basket',
+    ).toBe(true);
   });
 
   it('localizes the paid price into the storefront currency', async () => {
-    const result = await liveClient.app({
-      appId: 'com.mojang.minecraftpe',
-      lang: 'de',
-      country: 'de',
-    });
+    const result = await liveClient.app({ appId: MINECRAFT, lang: 'de', country: 'de' });
 
+    expectListingContract(result, 'german storefront listing');
     expect(result.free).toBe(false);
     expect(result.price).toBeGreaterThan(0);
     expect(result.currency).toBe('EUR');
@@ -140,11 +149,7 @@ liveDescribe('app live contract', () => {
   });
 
   it('exposes the trader legal fields on an eu storefront', async () => {
-    const result = await liveClient.app({
-      appId: 'com.google.android.apps.translate',
-      lang: 'de',
-      country: 'de',
-    });
+    const result = await liveClient.app({ appId: TRANSLATE, lang: 'de', country: 'de' });
 
     expect(result.developerLegalName?.trim().length).toBeGreaterThan(0);
     expect(result.developerLegalEmail?.trim().length).toBeGreaterThan(0);
@@ -163,10 +168,7 @@ liveDescribe('app live contract', () => {
     controller.abort();
 
     await expect(
-      liveClient.app({
-        appId: 'com.google.android.apps.translate',
-        requestOptions: { signal: controller.signal },
-      }),
+      liveClient.app({ appId: TRANSLATE, requestOptions: { signal: controller.signal } }),
     ).rejects.toMatchObject({ name: 'AbortError' });
   });
 });

--- a/e2e/contracts.ts
+++ b/e2e/contracts.ts
@@ -10,6 +10,8 @@ const HISTOGRAM_LAG_FLOOR = 10;
 const ONE_DECIMAL_SCORE_TEXT = /^\d+[.,]\d+$/;
 const ASCII_DIGIT = /[0-9]/;
 const NON_ASCII_DIGIT = /[^0-9]/g;
+const ABBREVIATED_SCALE_LETTER = /\p{L}/u;
+const QUOTED_PRICE_DIGIT = /\p{Nd}/u;
 const ANDROID_MARKET_LAUNCH_MS = 1_223_856_000_000;
 const CLOCK_SKEW_TOLERANCE_MS = 172_800_000;
 const OFFERLESS_PRICE_TEXT = 'Free';
@@ -33,7 +35,7 @@ function roundedScoreText(scoreText: string): number | undefined {
 }
 
 function groupedDigitsValue(text: string): number | undefined {
-  if (!ASCII_DIGIT.test(text)) {
+  if (!ASCII_DIGIT.test(text) || ABBREVIATED_SCALE_LETTER.test(text)) {
     return undefined;
   }
   return Number.parseInt(text.replace(NON_ASCII_DIGIT, ''), 10);
@@ -230,11 +232,13 @@ export function expectRatingSurfaceConsistency(listing: App, label: string): voi
 }
 
 export function expectPurchaseConsistency(listing: App, label: string): void {
-  const advertisesIAP = listing.IAPRange !== undefined && listing.IAPRange.length > 0;
+  if (listing.IAPRange === undefined || listing.IAPRange.length === 0) {
+    return;
+  }
   expect(
-    listing.offersIAP === true,
-    `${label}: offersIAP must agree with the presence of IAPRange`,
-  ).toBe(advertisesIAP);
+    QUOTED_PRICE_DIGIT.test(listing.IAPRange),
+    `${label}: IAPRange "${listing.IAPRange}" must quote a price`,
+  ).toBe(true);
 }
 
 export function expectReleaseStateConsistency(listing: App, label: string): void {

--- a/e2e/contracts.ts
+++ b/e2e/contracts.ts
@@ -1,0 +1,322 @@
+import { expect } from 'vitest';
+import type { App, AppItem, Review } from '../src/index.js';
+
+const PLAY_ORIGIN = 'https://play.google.com';
+const HTTPS_PROTOCOL = 'https:';
+const MAX_SCORE = 5;
+const SCORE_TEXT_ROUNDING_TOLERANCE = 0.051;
+const HISTOGRAM_LAG_RATIO = 0.01;
+const HISTOGRAM_LAG_FLOOR = 10;
+const ONE_DECIMAL_SCORE_TEXT = /^\d+[.,]\d+$/;
+const ASCII_DIGIT = /[0-9]/;
+const NON_ASCII_DIGIT = /[^0-9]/g;
+const ANDROID_MARKET_LAUNCH_MS = 1_223_856_000_000;
+const CLOCK_SKEW_TOLERANCE_MS = 172_800_000;
+const OFFERLESS_PRICE_TEXT = 'Free';
+
+export interface OfferFields {
+  price: number;
+  free: boolean;
+  currency?: string;
+}
+
+export interface RatingFields {
+  score?: number;
+  scoreText?: string;
+}
+
+function roundedScoreText(scoreText: string): number | undefined {
+  if (!ONE_DECIMAL_SCORE_TEXT.test(scoreText)) {
+    return undefined;
+  }
+  return Number.parseFloat(scoreText.replace(',', '.'));
+}
+
+function groupedDigitsValue(text: string): number | undefined {
+  if (!ASCII_DIGIT.test(text)) {
+    return undefined;
+  }
+  return Number.parseInt(text.replace(NON_ASCII_DIGIT, ''), 10);
+}
+
+function histogramTotal(histogram: App['histogram']): number {
+  return Object.values(histogram).reduce((sum, count) => sum + count, 0);
+}
+
+export function expectOfferConsistency(offer: OfferFields, label: string): void {
+  expect(Number.isFinite(offer.price), `${label}: price must be a finite number`).toBe(true);
+  expect(offer.price, `${label}: price must never be negative`).toBeGreaterThanOrEqual(0);
+
+  if (offer.free) {
+    expect(offer.price, `${label}: a free listing must cost zero`).toBe(0);
+    return;
+  }
+  if (offer.currency === undefined) {
+    expect(offer.price, `${label}: a listing without an offer node must cost zero`).toBe(0);
+    return;
+  }
+  expect(offer.price, `${label}: a paid listing must cost more than zero`).toBeGreaterThan(0);
+}
+
+export function expectRatingConsistency(rating: RatingFields, label: string): void {
+  expect(
+    rating.score === undefined,
+    `${label}: score and scoreText must be present together, got score=${String(rating.score)} scoreText=${String(rating.scoreText)}`,
+  ).toBe(rating.scoreText === undefined);
+
+  if (rating.score === undefined || rating.scoreText === undefined) {
+    return;
+  }
+
+  expect(rating.score, `${label}: score must not be below zero`).toBeGreaterThanOrEqual(0);
+  expect(
+    rating.score,
+    `${label}: score must not exceed ${MAX_SCORE.toString()}`,
+  ).toBeLessThanOrEqual(MAX_SCORE);
+
+  const rounded = roundedScoreText(rating.scoreText);
+  if (rounded === undefined) {
+    return;
+  }
+  expect(
+    Math.abs(rounded - rating.score),
+    `${label}: scoreText "${rating.scoreText}" must round score ${rating.score.toString()}`,
+  ).toBeLessThanOrEqual(SCORE_TEXT_ROUNDING_TOLERANCE);
+}
+
+export function expectAppItemContract(item: AppItem, label: string): void {
+  const scoped = `${label} ${item.appId}`;
+
+  expect(item.appId.length, `${label}: appId must not be empty`).toBeGreaterThan(0);
+  expect(item.title.length, `${scoped}: title must not be empty`).toBeGreaterThan(0);
+  expect(item.developer.length, `${scoped}: developer must not be empty`).toBeGreaterThan(0);
+  expect(new URL(item.url).origin, `${scoped}: url must address the play store`).toBe(PLAY_ORIGIN);
+  expect(item.url, `${scoped}: url must carry the same appId as the item`).toContain(item.appId);
+  expect(new URL(item.icon).protocol, `${scoped}: icon must be served over https`).toBe(
+    HTTPS_PROTOCOL,
+  );
+
+  expectOfferConsistency(item, scoped);
+  expectRatingConsistency(item, scoped);
+}
+
+export function expectAppItemsContract(items: readonly AppItem[], label: string): void {
+  for (const item of items) {
+    expectAppItemContract(item, label);
+  }
+  expect(
+    new Set(items.map((item) => item.appId)).size,
+    `${label}: every returned appId must be unique`,
+  ).toBe(items.length);
+}
+
+export function expectReviewContract(review: Review, label: string): void {
+  const scoped = `${label} ${review.id}`;
+
+  expect(review.id.length, `${label}: review id must not be empty`).toBeGreaterThan(0);
+  expect(review.userName.length, `${scoped}: userName must not be empty`).toBeGreaterThan(0);
+  expect(review.score, `${scoped}: score must be at least one star`).toBeGreaterThanOrEqual(1);
+  expect(
+    review.score,
+    `${scoped}: score must not exceed ${MAX_SCORE.toString()}`,
+  ).toBeLessThanOrEqual(MAX_SCORE);
+  expect(Number.isNaN(Date.parse(review.date)), `${scoped}: date must parse`).toBe(false);
+  expect(
+    Date.parse(review.date),
+    `${scoped}: date must sit after the store launched`,
+  ).toBeGreaterThan(ANDROID_MARKET_LAUNCH_MS);
+  expect(Date.parse(review.date), `${scoped}: date must not sit in the future`).toBeLessThan(
+    Date.now() + CLOCK_SKEW_TOLERANCE_MS,
+  );
+
+  if (review.replyDate !== undefined) {
+    expect(
+      Date.parse(review.replyDate),
+      `${scoped}: a developer reply must sit after the store launched`,
+    ).toBeGreaterThan(ANDROID_MARKET_LAUNCH_MS);
+    expect(
+      Date.parse(review.replyDate),
+      `${scoped}: a developer reply must not sit in the future`,
+    ).toBeLessThan(Date.now() + CLOCK_SKEW_TOLERANCE_MS);
+  }
+  if (review.thumbsUp !== undefined) {
+    expect(review.thumbsUp, `${scoped}: thumbsUp must not be negative`).toBeGreaterThanOrEqual(0);
+  }
+  if (review.userImage !== undefined) {
+    expect(new URL(review.userImage).protocol, `${scoped}: userImage must be https`).toBe(
+      HTTPS_PROTOCOL,
+    );
+  }
+}
+
+export function expectReviewsContract(reviews: readonly Review[], label: string): void {
+  for (const review of reviews) {
+    expectReviewContract(review, label);
+  }
+  expect(
+    new Set(reviews.map((review) => review.id)).size,
+    `${label}: every returned review id must be unique`,
+  ).toBe(reviews.length);
+}
+
+export function expectInstallsConsistency(listing: App, label: string): void {
+  expect(
+    listing.minInstalls !== undefined,
+    `${label}: installs and minInstalls must be present together`,
+  ).toBe(listing.installs !== undefined);
+
+  if (listing.maxInstalls !== undefined) {
+    expect(
+      listing.maxInstalls,
+      `${label}: maxInstalls must not be negative`,
+    ).toBeGreaterThanOrEqual(0);
+  }
+
+  if (listing.installs === undefined || listing.minInstalls === undefined) {
+    return;
+  }
+
+  expect(listing.minInstalls, `${label}: minInstalls must be positive`).toBeGreaterThan(0);
+  if (listing.maxInstalls !== undefined) {
+    expect(
+      listing.maxInstalls,
+      `${label}: maxInstalls must not fall below minInstalls`,
+    ).toBeGreaterThanOrEqual(listing.minInstalls);
+  }
+
+  const formatted = groupedDigitsValue(listing.installs);
+  if (formatted === undefined) {
+    return;
+  }
+  expect(formatted, `${label}: installs "${listing.installs}" must spell out minInstalls`).toBe(
+    listing.minInstalls,
+  );
+}
+
+export function expectRatingSurfaceConsistency(listing: App, label: string): void {
+  const total = histogramTotal(listing.histogram);
+  for (const [star, count] of Object.entries(listing.histogram)) {
+    expect(count, `${label}: histogram bucket ${star} must not be negative`).toBeGreaterThanOrEqual(
+      0,
+    );
+  }
+
+  if (listing.ratings === undefined) {
+    expect(
+      listing.score,
+      `${label}: a listing without ratings must carry no score`,
+    ).toBeUndefined();
+    expect(total, `${label}: a listing without ratings must carry an empty histogram`).toBe(0);
+    expect(
+      listing.reviews,
+      `${label}: a listing without ratings must carry no review count`,
+    ).toBeUndefined();
+    return;
+  }
+
+  expect(listing.score, `${label}: a rated listing must carry a score`).toBeDefined();
+
+  const lag = Math.max(HISTOGRAM_LAG_FLOOR, Math.ceil(listing.ratings * HISTOGRAM_LAG_RATIO));
+  const histogramMessage = `${label}: histogram total ${total.toString()} must track the rating count ${listing.ratings.toString()}`;
+  expect(total, histogramMessage).toBeGreaterThanOrEqual(listing.ratings - lag);
+  expect(total, histogramMessage).toBeLessThanOrEqual(listing.ratings + lag);
+
+  if (listing.reviews !== undefined) {
+    expect(
+      listing.reviews,
+      `${label}: the review count must not exceed the rating count`,
+    ).toBeLessThanOrEqual(listing.ratings);
+  }
+}
+
+export function expectPurchaseConsistency(listing: App, label: string): void {
+  const advertisesIAP = listing.IAPRange !== undefined && listing.IAPRange.length > 0;
+  expect(
+    listing.offersIAP === true,
+    `${label}: offersIAP must agree with the presence of IAPRange`,
+  ).toBe(advertisesIAP);
+}
+
+export function expectReleaseStateConsistency(listing: App, label: string): void {
+  if (!listing.preregister) {
+    return;
+  }
+
+  expect(listing.available, `${label}: a preregistration listing must read as available`).toBe(
+    true,
+  );
+  expect(
+    listing.released,
+    `${label}: a preregistration listing has no release date`,
+  ).toBeUndefined();
+  expect(listing.installs, `${label}: a preregistration listing has no installs`).toBeUndefined();
+  expect(
+    listing.minInstalls,
+    `${label}: a preregistration listing has no minInstalls`,
+  ).toBeUndefined();
+  expect(listing.ratings, `${label}: a preregistration listing has no ratings`).toBeUndefined();
+  expect(listing.score, `${label}: a preregistration listing has no score`).toBeUndefined();
+  expect(
+    histogramTotal(listing.histogram),
+    `${label}: a preregistration listing has an empty histogram`,
+  ).toBe(0);
+
+  if (listing.currency === undefined) {
+    expect(
+      listing.priceText,
+      `${label}: an offerless preregistration listing falls back to a free price text`,
+    ).toBe(OFFERLESS_PRICE_TEXT);
+  }
+}
+
+export function expectListingContract(listing: App, label: string): void {
+  const scoped = `${label} ${listing.appId}`;
+
+  expect(listing.appId.length, `${label}: appId must not be empty`).toBeGreaterThan(0);
+  expect(listing.title.length, `${scoped}: title must not be empty`).toBeGreaterThan(0);
+  expect(listing.description.length, `${scoped}: description must not be empty`).toBeGreaterThan(0);
+  expect(
+    listing.descriptionHTML.length,
+    `${scoped}: descriptionHTML must not be empty`,
+  ).toBeGreaterThan(0);
+  expect(listing.developer.length, `${scoped}: developer must not be empty`).toBeGreaterThan(0);
+  expect(listing.developerId.length, `${scoped}: developerId must not be empty`).toBeGreaterThan(0);
+  expect(listing.genreId.length, `${scoped}: genreId must not be empty`).toBeGreaterThan(0);
+  expect(new URL(listing.url).origin, `${scoped}: url must address the play store`).toBe(
+    PLAY_ORIGIN,
+  );
+  expect(listing.url, `${scoped}: url must carry the same appId as the listing`).toContain(
+    listing.appId,
+  );
+  expect(new URL(listing.icon).protocol, `${scoped}: icon must be served over https`).toBe(
+    HTTPS_PROTOCOL,
+  );
+  expect(
+    listing.screenshots.length,
+    `${scoped}: a listing must publish screenshots`,
+  ).toBeGreaterThan(0);
+  for (const screenshot of listing.screenshots) {
+    expect(new URL(screenshot).protocol, `${scoped}: screenshots must be served over https`).toBe(
+      HTTPS_PROTOCOL,
+    );
+  }
+  expect(listing.categories.length, `${scoped}: a listing must carry a category`).toBeGreaterThan(
+    0,
+  );
+  for (const category of listing.categories) {
+    expect(category.name.length, `${scoped}: category names must not be empty`).toBeGreaterThan(0);
+  }
+  expect(listing.updated, `${scoped}: updated must sit after the store launched`).toBeGreaterThan(
+    ANDROID_MARKET_LAUNCH_MS,
+  );
+  expect(listing.updated, `${scoped}: updated must not sit in the future`).toBeLessThan(
+    Date.now() + CLOCK_SKEW_TOLERANCE_MS,
+  );
+
+  expectOfferConsistency(listing, scoped);
+  expectRatingConsistency(listing, scoped);
+  expectRatingSurfaceConsistency(listing, scoped);
+  expectInstallsConsistency(listing, scoped);
+  expectPurchaseConsistency(listing, scoped);
+  expectReleaseStateConsistency(listing, scoped);
+}

--- a/e2e/datasafety.e2e.test.ts
+++ b/e2e/datasafety.e2e.test.ts
@@ -3,6 +3,7 @@ import type { IntegrityEvent } from '../src/index.js';
 import { liveClient, liveDescribe } from './helpers.js';
 
 const TRANSLATE = 'com.google.android.apps.translate';
+const DATA_RICH_COLLECTED_FLOOR = 10;
 
 liveDescribe('datasafety live contract', () => {
   it('returns collected data, security practices, and a privacy policy url', async () => {
@@ -46,7 +47,7 @@ liveDescribe('datasafety live contract', () => {
     const result = await liveClient.dataSafety({ appId: 'com.instagram.android' });
 
     expect(result.sharedData.length).toBeGreaterThan(0);
-    expect(result.collectedData.length).toBeGreaterThan(0);
+    expect(result.collectedData.length).toBeGreaterThan(DATA_RICH_COLLECTED_FLOOR);
     for (const entry of [...result.sharedData, ...result.collectedData]) {
       expect(entry.data.length).toBeGreaterThan(0);
       expect(entry.type.length).toBeGreaterThan(0);

--- a/e2e/datasafety.e2e.test.ts
+++ b/e2e/datasafety.e2e.test.ts
@@ -46,11 +46,14 @@ liveDescribe('datasafety live contract', () => {
     const result = await liveClient.dataSafety({ appId: 'com.instagram.android' });
 
     expect(result.sharedData.length).toBeGreaterThan(0);
-    expect(result.collectedData.length).toBeGreaterThan(10);
-    for (const entry of result.sharedData) {
+    expect(result.collectedData.length).toBeGreaterThan(0);
+    for (const entry of [...result.sharedData, ...result.collectedData]) {
       expect(entry.data.length).toBeGreaterThan(0);
       expect(entry.type.length).toBeGreaterThan(0);
       expect(typeof entry.optional).toBe('boolean');
+      if (entry.purpose !== undefined) {
+        expect(entry.purpose.length).toBeGreaterThan(0);
+      }
     }
     expect(result.sharedData.some((entry) => entry.purpose !== undefined)).toBe(true);
   });

--- a/e2e/developer.e2e.test.ts
+++ b/e2e/developer.e2e.test.ts
@@ -2,22 +2,25 @@ import { expect, it } from 'vitest';
 import { clientFromOptions } from '../src/core/http.js';
 import { fetchDeveloperFirstPage } from '../src/features/developer/developer.js';
 import { NotFoundError, type DegradationEvent, type DeveloperApp } from '../src/index.js';
+import { expectAppItemsContract } from './contracts.js';
 import { expectFieldCoverage, liveClient, liveDescribe } from './helpers.js';
 
 const GOOGLE_DEV_ID = '5700313618786177705';
+const FIRST_PAGE_NUM = 40;
+const MULTI_PAGE_NUM = 100;
+const SLICE_NUM = 60;
 
 liveDescribe('developer live contract', () => {
   it('returns Google apps for the numeric developer id', async () => {
     const items = (await liveClient.developer({
       devId: GOOGLE_DEV_ID,
-      num: 40,
+      num: FIRST_PAGE_NUM,
     })) as DeveloperApp[];
 
-    expect(items.length).toBeGreaterThanOrEqual(30);
-    expect(new Set(items.map((item) => item.appId)).size).toBe(items.length);
+    expect(items).toHaveLength(FIRST_PAGE_NUM);
+    expectAppItemsContract(items, 'google developer page');
     for (const item of items) {
       expect(item.developer).toContain('Google');
-      expect(new URL(item.url).origin).toBe('https://play.google.com');
     }
   });
 
@@ -25,15 +28,14 @@ liveDescribe('developer live contract', () => {
     const events: DegradationEvent[] = [];
     const items = (await liveClient.developer({
       devId: GOOGLE_DEV_ID,
-      num: 100,
+      num: MULTI_PAGE_NUM,
       onDegradation: (event) => events.push(event),
     })) as DeveloperApp[];
 
-    expect(items.length).toBeGreaterThanOrEqual(80);
-    expect(new Set(items.map((item) => item.appId)).size).toBe(items.length);
+    expect(items).toHaveLength(MULTI_PAGE_NUM);
+    expectAppItemsContract(items, 'google developer continuation');
     for (const item of items) {
       expect(item.developer).toContain('Google');
-      expect(new URL(item.url).origin).toBe('https://play.google.com');
     }
 
     expectFieldCoverage('developer', items, {
@@ -47,10 +49,10 @@ liveDescribe('developer live contract', () => {
   it('slices to exactly num when more apps are available', async () => {
     const items = (await liveClient.developer({
       devId: GOOGLE_DEV_ID,
-      num: 60,
+      num: SLICE_NUM,
     })) as DeveloperApp[];
 
-    expect(items).toHaveLength(60);
+    expect(items).toHaveLength(SLICE_NUM);
   });
 
   it('confirms the numeric first page still requires a continuation', async () => {
@@ -60,7 +62,7 @@ liveDescribe('developer live contract', () => {
     );
 
     expect(apps.length).toBeGreaterThan(0);
-    expect(apps.length).toBeLessThan(40);
+    expect(apps.length).toBeLessThan(FIRST_PAGE_NUM);
     expect(token).toBeDefined();
   });
 
@@ -73,22 +75,20 @@ liveDescribe('developer live contract', () => {
   it('includes the Where Am I game when resolving the Adex77 name id', async () => {
     const items = (await liveClient.developer({ devId: 'Adex77' })) as DeveloperApp[];
 
-    expect(items.length).toBeGreaterThan(0);
     expect(items.map((item) => item.appId)).toContain('com.adex77.WhereAmI');
+    expectAppItemsContract(items, 'adex77 developer page');
     for (const item of items) {
       expect(item.developer).toBe('Adex77');
-      expect(new URL(item.url).origin).toBe('https://play.google.com');
     }
   });
 
   it('resolves a developer name containing a comma and space', async () => {
     const items = (await liveClient.developer({ devId: 'Netflix, Inc.' })) as DeveloperApp[];
 
-    expect(items.length).toBeGreaterThan(0);
     expect(items.map((item) => item.appId)).toContain('com.netflix.mediaclient');
+    expectAppItemsContract(items, 'comma developer page');
     for (const item of items) {
       expect(item.developer).toBe('Netflix, Inc.');
-      expect(new URL(item.url).origin).toBe('https://play.google.com');
     }
   });
 
@@ -108,7 +108,7 @@ liveDescribe('developer live contract', () => {
     const items = (await liveClient.developer({ devId: 'Adex77', num: 500 })) as DeveloperApp[];
 
     expect(items.length).toBeGreaterThanOrEqual(1);
-    expect(items.length).toBeLessThan(100);
-    expect(new Set(items.map((item) => item.appId)).size).toBe(items.length);
+    expect(items.length).toBeLessThan(500);
+    expectAppItemsContract(items, 'exhausted developer catalog');
   });
 });

--- a/e2e/edgeCases.e2e.test.ts
+++ b/e2e/edgeCases.e2e.test.ts
@@ -1,20 +1,33 @@
 import { expect, it } from 'vitest';
-import type { IntegrityEvent } from '../src/index.js';
+import { permission } from '../src/index.js';
+import type { App, IntegrityEvent, ListItem, SearchResult, SimilarApp } from '../src/index.js';
+import { expectAppItemsContract, expectListingContract } from './contracts.js';
 import { liveClient, liveDescribe } from './helpers.js';
 
-const UNREVIEWED = 'app.hobby_tracker_app';
-const UNRATED = 'com.geoguess.app';
-const SMALL_CATALOGUE = 'com.adex77.memefast.mememaker';
+const SPARSE_REVIEW_ANCHOR = 'app.hobby_tracker_app';
+const SPARSE_RATING_ANCHOR = 'com.geoguess.app';
+const COMMENT_ROOT_ANCHOR = 'com.adex77.memefast.mememaker';
+const SPARSE_LISTINGS = [SPARSE_REVIEW_ANCHOR, SPARSE_RATING_ANCHOR, COMMENT_ROOT_ANCHOR];
+const SPARSE_SAFETY_ANCHOR = 'com.hDel.codeblue';
+const SPARSE_SIMILAR_ANCHOR = 'org.asccp.app2019';
 const REGION_RESTRICTED = 'com.google.android.apps.nbu.paisa.user';
-const PLAY_PASS = 'com.noodlecake.altosodyssey';
+const REGION_RESTRICTED_HOME = 'in';
+const PLAY_PASS_CANDIDATES = [
+  'com.noodlecake.altosodyssey',
+  'com.chucklefish.stardewvalley',
+  'com.ustwo.monumentvalley2',
+  'com.playdead.limbo.full',
+];
 const DISCOUNTED = 'com.humble.SlayTheSpire';
-const PLAY_PASS_PAID = 'com.chucklefish.stardewvalley';
-const NO_SIMILAR = 'org.asccp.app2019';
-const NO_COLLECTED_DATA = 'com.hDel.codeblue';
-const NON_LATIN = 'jp.naver.line.android';
+const IAP_CANDIDATES = ['com.roblox.client', 'com.king.candycrushsaga', 'com.mojang.minecraftpe'];
 const ZERO_DECIMAL_PAID = 'com.mojang.minecraftpe';
+const NON_LATIN = 'jp.naver.line.android';
 const RTL_STOREFRONT = 'com.whatsapp';
-const IN_APP_PURCHASES = 'com.roblox.client';
+
+const SPARSE_PAID_COLLECTIONS = [
+  { category: 'DATING', collection: 'TOP_PAID' },
+  { category: 'COMICS', collection: 'TOP_PAID' },
+] as const;
 
 const PREREGISTRATION_CANDIDATES = [
   'com.ironhidegames.android.kingdomrush6.genesis',
@@ -26,6 +39,7 @@ const PREREGISTRATION_CANDIDATES = [
   'com.dreamloft.grumpykingdom',
 ];
 
+const SPARSE_COLLECTION_NUM = 20;
 const EMPTY_HISTOGRAM = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
 const YEAR_2000_MS = 946684800000;
 const YEAR_2100_MS = 4102444800000;
@@ -39,80 +53,110 @@ function expectOnlyAppCommentEvents(events: IntegrityEvent[]): void {
   }
 }
 
-liveDescribe('unrated and unreviewed listings live contract', () => {
-  it('returns a complete listing for an app with no ratings at all', async () => {
+function describeRatingState(listing: App): string {
+  return listing.ratings === undefined ? 'unrated' : `${listing.ratings.toString()} ratings`;
+}
+
+liveDescribe('sparse listings live contract', () => {
+  it('resolves a complete listing for every sparse anchor', async ({ annotate }) => {
     const events: IntegrityEvent[] = [];
-    const result = await liveClient.app({
-      appId: UNRATED,
-      onIntegrityEvent: (event) => events.push(event),
-    });
+    const listings = await Promise.all(
+      SPARSE_LISTINGS.map((appId) =>
+        liveClient.app({ appId, onIntegrityEvent: (event) => events.push(event) }),
+      ),
+    );
 
-    expect(result.appId).toBe(UNRATED);
-    expect(result.title.length).toBeGreaterThan(0);
-    expect(result.description.length).toBeGreaterThan(0);
-    expect(result.score).toBeUndefined();
-    expect(result.scoreText).toBeUndefined();
-    expect(result.ratings).toBeUndefined();
-    expect(result.histogram).toEqual(EMPTY_HISTOGRAM);
-    expect(result.free).toBe(true);
-    expect(result.available).toBe(true);
-    expect(result.screenshots.length).toBeGreaterThan(0);
+    for (const listing of listings) {
+      expectListingContract(listing, 'sparse listing');
+    }
     expectOnlyAppCommentEvents(events);
+
+    await annotate(
+      listings.map((listing) => `${listing.appId}: ${describeRatingState(listing)}`).join(', '),
+      'notice',
+    );
   });
 
-  it('returns an empty review page for an app that has no reviews', async () => {
-    const result = await liveClient.reviews({ appId: UNREVIEWED, num: 20 });
+  it('pairs the rating surface with the review surface for a sparse listing', async ({
+    annotate,
+  }) => {
+    const listing = await liveClient.app({ appId: SPARSE_REVIEW_ANCHOR });
+    const page = await liveClient.reviews({ appId: SPARSE_REVIEW_ANCHOR, num: 20 });
 
-    expect(result.data).toEqual([]);
-    expect(result.nextPaginationToken).toBeNull();
+    if (listing.ratings === undefined) {
+      expect(page.data).toEqual([]);
+      expect(page.nextPaginationToken).toBeNull();
+      await annotate(`${SPARSE_REVIEW_ANCHOR} still carries no ratings`, 'notice');
+      return;
+    }
+
+    expect(page.data.length).toBeGreaterThan(0);
+    for (const review of page.data) {
+      expect(review.id.length).toBeGreaterThan(0);
+      expect(review.userName.length).toBeGreaterThan(0);
+      expect(review.score).toBeGreaterThanOrEqual(1);
+      expect(review.score).toBeLessThanOrEqual(5);
+      expect(Number.isNaN(Date.parse(review.date))).toBe(false);
+    }
+    await annotate(`${SPARSE_REVIEW_ANCHOR} now reports ${describeRatingState(listing)}`, 'notice');
   });
 
-  it('stops cleanly when paginating an app that has no reviews', async () => {
+  it('stops cleanly when paginating a sparse listing', async () => {
     const events: IntegrityEvent[] = [];
     const result = await liveClient.reviews({
-      appId: UNREVIEWED,
+      appId: SPARSE_REVIEW_ANCHOR,
       paginate: true,
       onIntegrityEvent: (event) => events.push(event),
     });
 
-    expect(result.data).toEqual([]);
-    expect(result.nextPaginationToken).toBeNull();
+    expect(new Set(result.data.map((review) => review.id)).size).toBe(result.data.length);
+    if (result.data.length === 0) {
+      expect(result.nextPaginationToken).toBeNull();
+    }
     expect(events).toEqual([]);
   });
 
-  it('returns details and a safety report for a listing with no ratings', async () => {
-    const details = await liveClient.app({ appId: UNREVIEWED });
-    const report = await liveClient.dataSafety({ appId: UNREVIEWED });
+  it('returns a well formed safety report for a sparse listing', async ({ annotate }) => {
+    const report = await liveClient.dataSafety({ appId: SPARSE_SAFETY_ANCHOR });
 
-    expect(details.histogram).toEqual(EMPTY_HISTOGRAM);
-    expect(details.reviews).toBeUndefined();
-    expect(details.minInstalls).toBeGreaterThan(0);
+    expect(Array.isArray(report.sharedData)).toBe(true);
     expect(Array.isArray(report.collectedData)).toBe(true);
     expect(Array.isArray(report.securityPractices)).toBe(true);
+    for (const entry of [...report.sharedData, ...report.collectedData]) {
+      expect(entry.data.length).toBeGreaterThan(0);
+      expect(entry.type.length).toBeGreaterThan(0);
+      expect(typeof entry.optional).toBe('boolean');
+    }
+    expect(report.privacyPolicyUrl?.startsWith('http')).toBe(true);
+
+    await annotate(
+      `${SPARSE_SAFETY_ANCHOR} declares ${report.collectedData.length.toString()} collected and ${report.sharedData.length.toString()} shared entries`,
+      'notice',
+    );
   });
 
-  it('returns permissions for an app that declares no common permission section', async () => {
-    const result = await liveClient.permissions({ appId: UNREVIEWED });
+  it('returns typed permission entries for a sparse listing', async () => {
+    const result = await liveClient.permissions({ appId: SPARSE_REVIEW_ANCHOR });
 
-    expect(result.length).toBeGreaterThan(0);
+    expect(Array.isArray(result)).toBe(true);
     for (const entry of result) {
       const item = entry as { permission: string; type: number };
       expect(item.permission.length).toBeGreaterThan(0);
+      expect([permission.COMMON, permission.OTHER]).toContain(item.type);
     }
   });
 
-  it('returns unrated results alongside rated ones in a single search page', async () => {
-    const results = await liveClient.search({ term: 'hobby tracker', num: 30 });
+  it('keeps rating fields consistent across a mixed search page', async ({ annotate }) => {
+    const results = (await liveClient.search({ term: 'hobby tracker', num: 30 })) as SearchResult[];
 
     expect(results.length).toBeGreaterThan(10);
-    expect(results.some((item) => item.score === undefined)).toBe(true);
-    for (const item of results) {
-      expect(item.appId.length).toBeGreaterThan(0);
-      expect(item.title.length).toBeGreaterThan(0);
-      expect(item.url.startsWith('https://')).toBe(true);
-      expect(typeof item.price).toBe('number');
-      expect(typeof item.free).toBe('boolean');
-    }
+    expectAppItemsContract(results, 'hobby tracker search');
+
+    const unrated = results.filter((item) => item.score === undefined).length;
+    await annotate(
+      `${unrated.toString()} of ${results.length.toString()} results carry no score`,
+      'notice',
+    );
   });
 });
 
@@ -127,76 +171,73 @@ liveDescribe('availability and catalogue edges live contract', () => {
 
     expect(result.available).toBe(false);
     expect(result.preregister).toBe(false);
-    expect(result.title.length).toBeGreaterThan(0);
+    expectListingContract(result, 'region restricted listing');
     expect(result.ratings).toBeGreaterThan(0);
     expect(events).toEqual([]);
   });
 
   it('marks the same listing available on its own storefront', async () => {
-    const result = await liveClient.app({ appId: REGION_RESTRICTED, country: 'in' });
+    const result = await liveClient.app({
+      appId: REGION_RESTRICTED,
+      country: REGION_RESTRICTED_HOME,
+    });
 
     expect(result.available).toBe(true);
+    expectListingContract(result, 'home storefront listing');
   });
 
   it('resolves details across live comment root variants', async () => {
     const events: IntegrityEvent[] = [];
     const result = await liveClient.app({
-      appId: SMALL_CATALOGUE,
+      appId: COMMENT_ROOT_ANCHOR,
       onIntegrityEvent: (event) => events.push(event),
     });
 
-    expect(result.appId).toBe(SMALL_CATALOGUE);
     for (const comment of result.comments) {
       expect(comment.length).toBeGreaterThan(0);
     }
-    expect(result.title.length).toBeGreaterThan(0);
-    expect(result.minInstalls).toBeGreaterThan(0);
+    expectListingContract(result, 'comment root variant listing');
     expectOnlyAppCommentEvents(events);
   });
 
-  it('returns an empty similar cluster for an app with no recommendations', async () => {
+  it('returns a well formed similar cluster for a low profile listing', async ({ annotate }) => {
     const events: IntegrityEvent[] = [];
-    const results = await liveClient.similar({
-      appId: NO_SIMILAR,
+    const results = (await liveClient.similar({
+      appId: SPARSE_SIMILAR_ANCHOR,
       onIntegrityEvent: (event) => events.push(event),
-    });
+    })) as SimilarApp[];
 
-    expect(results).toEqual([]);
+    expect(Array.isArray(results)).toBe(true);
+    expectAppItemsContract(results, 'low profile similar cluster');
+    expect(results.some((item) => item.appId === SPARSE_SIMILAR_ANCHOR)).toBe(false);
     expect(events).toEqual([]);
+
+    await annotate(
+      `${SPARSE_SIMILAR_ANCHOR} is recommended alongside ${results.length.toString()} apps`,
+      'notice',
+    );
   });
 
-  it('returns an empty safety report for an app that collects no data', async () => {
-    const report = await liveClient.dataSafety({ appId: NO_COLLECTED_DATA });
+  it('returns only paid entries for sparsely populated paid collections', async ({ annotate }) => {
+    const counts: string[] = [];
 
-    expect(report.sharedData).toEqual([]);
-    expect(report.collectedData).toEqual([]);
-    expect(report.securityPractices).toEqual([]);
-  });
+    for (const { category, collection } of SPARSE_PAID_COLLECTIONS) {
+      const results = (await liveClient.list({
+        category,
+        collection,
+        num: SPARSE_COLLECTION_NUM,
+      })) as ListItem[];
 
-  it('returns an empty list for a category and collection with no entries', async () => {
-    const results = await liveClient.list({
-      category: 'DATING',
-      collection: 'TOP_PAID',
-      num: 20,
-    });
-
-    expect(results).toEqual([]);
-  });
-
-  it('returns the few entries of a sparsely populated paid collection', async () => {
-    const results = await liveClient.list({
-      category: 'COMICS',
-      collection: 'TOP_PAID',
-      num: 20,
-    });
-
-    expect(results.length).toBeGreaterThan(0);
-    expect(results.length).toBeLessThan(20);
-    for (const item of results) {
-      expect(item.appId.length).toBeGreaterThan(0);
-      expect(item.free).toBe(false);
-      expect(item.price).toBeGreaterThan(0);
+      expect(results.length).toBeLessThanOrEqual(SPARSE_COLLECTION_NUM);
+      expectAppItemsContract(results, `${category} ${collection}`);
+      for (const item of results) {
+        expect(item.free).toBe(false);
+        expect(item.price).toBeGreaterThan(0);
+      }
+      counts.push(`${category}: ${results.length.toString()}`);
     }
+
+    await annotate(counts.join(', '), 'notice');
   });
 });
 
@@ -204,6 +245,7 @@ liveDescribe('commercial model edges live contract', () => {
   it('keeps discount fields consistent for a paid listing', async () => {
     const result = await liveClient.app({ appId: DISCOUNTED });
 
+    expectListingContract(result, 'discounted listing');
     expect(result.free).toBe(false);
     expect(result.price).toBeGreaterThan(0);
     expect(result.currency).toBe('USD');
@@ -217,25 +259,52 @@ liveDescribe('commercial model edges live contract', () => {
     expect(result.originalPrice).toBeGreaterThan(result.price);
   });
 
-  it('reports the play pass flag for subscription catalogue titles', async () => {
-    const bundled = await liveClient.app({ appId: PLAY_PASS });
-    const paid = await liveClient.app({ appId: PLAY_PASS_PAID });
+  it('reports the play pass flag across the subscription catalogue anchors', async ({
+    annotate,
+  }) => {
+    const listings = await Promise.all(
+      PLAY_PASS_CANDIDATES.map((appId) => liveClient.app({ appId })),
+    );
 
-    expect(bundled.isAvailableInPlayPass).toBe(true);
-    expect(bundled.available).toBe(true);
-    expect(paid.isAvailableInPlayPass).toBe(true);
-    expect(paid.free).toBe(false);
-    expect(paid.price).toBeGreaterThan(0);
+    for (const listing of listings) {
+      expectListingContract(listing, 'play pass candidate');
+      expect(typeof listing.isAvailableInPlayPass).toBe('boolean');
+      if (listing.isAvailableInPlayPass) {
+        expect(listing.available).toBe(true);
+      }
+    }
+
+    const bundled = listings.filter((listing) => listing.isAvailableInPlayPass);
+    expect(
+      bundled.length,
+      'no play pass anchor still reports the subscription flag, re-anchor the pool',
+    ).toBeGreaterThan(0);
+    await annotate(
+      `${bundled.length.toString()} of ${listings.length.toString()} anchors are bundled: ${bundled.map((listing) => listing.appId).join(', ')}`,
+      'notice',
+    );
   });
 
-  it('reports an in app purchase range without ad support', async () => {
-    const result = await liveClient.app({ appId: IN_APP_PURCHASES });
+  it('reports an in app purchase range alongside the purchase flag', async ({ annotate }) => {
+    const listings = await Promise.all(IAP_CANDIDATES.map((appId) => liveClient.app({ appId })));
 
-    expect(result.free).toBe(true);
-    expect(result.price).toBe(0);
-    expect(result.offersIAP).toBe(true);
-    expect(result.IAPRange?.trim().length).toBeGreaterThan(0);
-    expect(typeof result.adSupported).toBe('boolean');
+    for (const listing of listings) {
+      expectListingContract(listing, 'in app purchase candidate');
+      expect(typeof listing.adSupported).toBe('boolean');
+    }
+
+    const offering = listings.filter((listing) => listing.offersIAP === true);
+    expect(
+      offering.length,
+      'no in app purchase anchor advertises a range, re-anchor the pool',
+    ).toBeGreaterThan(0);
+    for (const listing of offering) {
+      expect(listing.IAPRange?.trim().length).toBeGreaterThan(0);
+    }
+    await annotate(
+      offering.map((listing) => `${listing.appId}: ${listing.IAPRange ?? ''}`).join(' | '),
+      'notice',
+    );
   });
 
   it('parses a paid price in a currency without minor units', async () => {
@@ -245,6 +314,7 @@ liveDescribe('commercial model edges live contract', () => {
       country: 'jp',
     });
 
+    expectListingContract(result, 'zero decimal storefront listing');
     expect(result.currency).toBe('JPY');
     expect(result.free).toBe(false);
     expect(result.price).toBeGreaterThan(0);
@@ -254,7 +324,7 @@ liveDescribe('commercial model edges live contract', () => {
 });
 
 liveDescribe('preregistration listings live contract', () => {
-  it('resolves every preregistration candidate without a spec failure', async () => {
+  it('resolves every preregistration candidate without a spec failure', async ({ annotate }) => {
     const events: IntegrityEvent[] = [];
     const results = await Promise.all(
       PREREGISTRATION_CANDIDATES.map((appId) =>
@@ -263,9 +333,7 @@ liveDescribe('preregistration listings live contract', () => {
     );
 
     for (const result of results) {
-      expect(result.title.length).toBeGreaterThan(0);
-      expect(result.description.length).toBeGreaterThan(0);
-      expect(result.screenshots.length).toBeGreaterThan(0);
+      expectListingContract(result, 'preregistration candidate');
       expect(typeof result.preregister).toBe('boolean');
       expect(typeof result.earlyAccessEnabled).toBe('boolean');
     }
@@ -273,15 +341,20 @@ liveDescribe('preregistration listings live contract', () => {
       expect(event.reason).toBe('optional-section-parse');
       expect(event.context).toBe('app comments');
     }
+
+    const preregistering = results.filter((result) => result.preregister);
+    const earlyAccess = results.filter((result) => result.earlyAccessEnabled);
+    await annotate(
+      `${preregistering.length.toString()} of ${results.length.toString()} candidates still preregister, ${earlyAccess.length.toString()} offer early access`,
+      'notice',
+    );
   });
 
-  it('reports an offerless listing for the candidates still in preregistration', async () => {
+  it('serves an offerless listing for candidates that have not launched', async ({ annotate }) => {
     const results = await Promise.all(
       PREREGISTRATION_CANDIDATES.map((appId) => liveClient.app({ appId })),
     );
     const preregistering = results.filter((result) => result.preregister);
-
-    expect(preregistering.length).toBeGreaterThan(0);
 
     for (const result of preregistering) {
       expect(result.price).toBe(0);
@@ -296,25 +369,23 @@ liveDescribe('preregistration listings live contract', () => {
       expect(result.histogram).toEqual(EMPTY_HISTOGRAM);
       expect(result.released).toBeUndefined();
     }
-  });
 
-  it('covers early access among the preregistration candidates', async () => {
-    const results = await Promise.all(
-      PREREGISTRATION_CANDIDATES.map((appId) => liveClient.app({ appId })),
-    );
-    const earlyAccess = results.filter((result) => result.earlyAccessEnabled);
-
-    expect(earlyAccess.length).toBeGreaterThan(0);
-
-    for (const result of earlyAccess) {
-      expect(result.preregister).toBe(true);
-      expect(result.title.length).toBeGreaterThan(0);
+    const launched = results.filter((result) => !result.preregister);
+    for (const result of launched) {
+      expect(result.installs?.length).toBeGreaterThan(0);
+      expect(result.minInstalls).toBeGreaterThan(0);
     }
+
+    await annotate(
+      `${preregistering.length.toString()} unlaunched, ${launched.length.toString()} launched`,
+      'notice',
+    );
   });
 
-  it('serves reports and neighbours for a preregistration listing', async () => {
+  it('serves reports and neighbours for a candidate listing', async () => {
     const appId = PREREGISTRATION_CANDIDATES[0] ?? '';
-    const [permissions, safety, similar, reviews] = await Promise.all([
+    const [listing, permissions, safety, similar, reviews] = await Promise.all([
+      liveClient.app({ appId }),
       liveClient.permissions({ appId }),
       liveClient.dataSafety({ appId }),
       liveClient.similar({ appId }),
@@ -323,20 +394,25 @@ liveDescribe('preregistration listings live contract', () => {
 
     expect(permissions.length).toBeGreaterThan(0);
     expect(safety.privacyPolicyUrl?.length).toBeGreaterThan(0);
-    expect(similar.length).toBeGreaterThan(0);
-    expect(reviews.data).toEqual([]);
-    expect(reviews.nextPaginationToken).toBeNull();
+    expectAppItemsContract(similar as SimilarApp[], 'candidate similar cluster');
+
+    if (listing.ratings === undefined) {
+      expect(reviews.data).toEqual([]);
+      expect(reviews.nextPaginationToken).toBeNull();
+      return;
+    }
+    expect(reviews.data.length).toBeGreaterThan(0);
+    for (const review of reviews.data) {
+      expect(review.score).toBeGreaterThanOrEqual(1);
+      expect(review.score).toBeLessThanOrEqual(5);
+    }
   });
 
-  it('keeps a preregistration match in a search page instead of failing it', async () => {
-    const results = await liveClient.search({ term: 'Reigns Beyond', num: 20 });
+  it('keeps every match of a launch title search parseable', async () => {
+    const results = (await liveClient.search({ term: 'Reigns Beyond', num: 20 })) as SearchResult[];
 
     expect(results.length).toBeGreaterThan(0);
-    for (const item of results) {
-      expect(typeof item.free).toBe('boolean');
-      expect(Number.isFinite(item.price)).toBe(true);
-    }
-    expect(results.some((item) => item.appId === 'com.devolver.reignsbeyond')).toBe(true);
+    expectAppItemsContract(results, 'launch title search');
   });
 });
 
@@ -344,7 +420,7 @@ liveDescribe('localized listing edges live contract', () => {
   it('returns a non latin title and a stable genre id', async () => {
     const result = await liveClient.app({ appId: NON_LATIN, lang: 'ja', country: 'jp' });
 
-    expect(result.title.length).toBeGreaterThan(0);
+    expectListingContract(result, 'non latin listing');
     expect(/[^\x20-\x7e]/.test(result.title)).toBe(true);
     expect(result.genreId).toBe('COMMUNICATION');
     expect(result.free).toBe(true);
@@ -357,10 +433,9 @@ liveDescribe('localized listing edges live contract', () => {
       country: 'eg',
     });
 
-    expect(result.title.length).toBeGreaterThan(0);
+    expectListingContract(result, 'right to left listing');
     expect(/[^\x20-\x7e]/.test(result.title)).toBe(true);
     expect(result.installs?.includes('+')).toBe(true);
-    expect(result.minInstalls).toBeGreaterThan(0);
     expect(result.free).toBe(true);
   });
 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -10,6 +10,18 @@ export const liveDescribe = describe.skipIf(LIVE_TESTS_DISABLED);
 
 export const liveClient = createClient({ throttle: REQUESTS_PER_SECOND });
 
+export function expectFieldFilledSomewhere(
+  context: string,
+  items: readonly Record<string, unknown>[],
+  fields: readonly string[],
+): void {
+  for (const field of fields) {
+    const { filled, total } = fieldCoverage(items, field);
+    const message = `${context}: field "${field}" is empty across all ${total.toString()} anchors`;
+    expect(filled, message).toBeGreaterThan(0);
+  }
+}
+
 export function expectFieldCoverage(
   context: string,
   items: readonly Record<string, unknown>[],

--- a/e2e/iterators.e2e.test.ts
+++ b/e2e/iterators.e2e.test.ts
@@ -1,9 +1,16 @@
 import { expect, it } from 'vitest';
-import { type DegradationEvent, type IntegrityEvent } from '../src/index.js';
+import { type DegradationEvent, type IntegrityEvent, type Review } from '../src/index.js';
+import { expectAppItemContract, expectReviewContract, expectReviewsContract } from './contracts.js';
 import { liveClient, liveDescribe } from './helpers.js';
 
 const WHATSAPP = 'com.whatsapp';
+const GEO_GAME = 'com.adex77.WhereAmI';
 const FIRST_PAGE_SIZE = 150;
+const STREAM_LIMIT = 200;
+const SEARCH_STREAM_LIMIT = 30;
+const DEVELOPER_STREAM_LIMIT = 40;
+const REVIEWS_ALL_LIMIT = 50;
+const REVIEWS_ALL_CEILING = 5000;
 
 liveDescribe('iterators live contract', () => {
   it('streams reviews across the first page boundary', async () => {
@@ -13,37 +20,31 @@ liveDescribe('iterators live contract', () => {
       appId: WHATSAPP,
       onIntegrityEvent: (event) => events.push(event),
     })) {
-      expect(review.id.length).toBeGreaterThan(0);
-      expect(review.userName.length).toBeGreaterThan(0);
-      expect(review.score).toBeGreaterThanOrEqual(1);
-      expect(review.score).toBeLessThanOrEqual(5);
-      expect(Number.isNaN(Date.parse(review.date))).toBe(false);
+      expectReviewContract(review, 'streamed review');
       collected.push(review.id);
-      if (collected.length === 200) {
+      if (collected.length === STREAM_LIMIT) {
         break;
       }
     }
 
-    expect(collected).toHaveLength(200);
+    expect(collected).toHaveLength(STREAM_LIMIT);
     expect(collected.length).toBeGreaterThan(FIRST_PAGE_SIZE);
-    expect(new Set(collected).size).toBe(200);
+    expect(new Set(collected).size).toBe(STREAM_LIMIT);
     expect(events).toEqual([]);
   });
 
   it('streams thirty search results for a broad term and stops', async () => {
     const collected: string[] = [];
     for await (const result of liveClient.searchIterator({ term: 'geography quiz' })) {
-      expect(result.appId.length).toBeGreaterThan(0);
-      expect(result.title.length).toBeGreaterThan(0);
-      expect(new URL(result.url).origin).toBe('https://play.google.com');
+      expectAppItemContract(result, 'streamed search result');
       collected.push(result.appId);
-      if (collected.length === 30) {
+      if (collected.length === SEARCH_STREAM_LIMIT) {
         break;
       }
     }
 
-    expect(collected).toHaveLength(30);
-    expect(new Set(collected).size).toBe(30);
+    expect(collected).toHaveLength(SEARCH_STREAM_LIMIT);
+    expect(new Set(collected).size).toBe(SEARCH_STREAM_LIMIT);
   });
 
   it('streams developer apps across the first page boundary', async () => {
@@ -53,16 +54,15 @@ liveDescribe('iterators live contract', () => {
       devId: '5700313618786177705',
       onDegradation: (event) => events.push(event),
     })) {
-      expect(item.appId.length).toBeGreaterThan(0);
-      expect(new URL(item.url).origin).toBe('https://play.google.com');
+      expectAppItemContract(item, 'streamed developer app');
       collected.push(item.appId);
-      if (collected.length === 40) {
+      if (collected.length === DEVELOPER_STREAM_LIMIT) {
         break;
       }
     }
 
-    expect(collected).toHaveLength(40);
-    expect(new Set(collected).size).toBe(40);
+    expect(collected).toHaveLength(DEVELOPER_STREAM_LIMIT);
+    expect(new Set(collected).size).toBe(DEVELOPER_STREAM_LIMIT);
     expect(events).toEqual([]);
   });
 
@@ -89,21 +89,20 @@ liveDescribe('iterators live contract', () => {
   });
 
   it('collects exactly maxReviews reviews through reviewsAll', async () => {
-    const reviews = await liveClient.reviewsAll({ appId: WHATSAPP, maxReviews: 50 });
+    const reviews: Review[] = await liveClient.reviewsAll({
+      appId: WHATSAPP,
+      maxReviews: REVIEWS_ALL_LIMIT,
+    });
 
-    expect(reviews).toHaveLength(50);
-    for (const review of reviews) {
-      expect(review.score).toBeGreaterThanOrEqual(1);
-      expect(review.score).toBeLessThanOrEqual(5);
-      expect(Number.isNaN(Date.parse(review.date))).toBe(false);
-    }
+    expect(reviews).toHaveLength(REVIEWS_ALL_LIMIT);
+    expectReviewsContract(reviews, 'reviewsAll page');
   });
 
   it('drains reviewsAll without maxReviews on a small catalog app', async () => {
-    const reviews = await liveClient.reviewsAll({ appId: 'com.adex77.WhereAmI' });
+    const reviews: Review[] = await liveClient.reviewsAll({ appId: GEO_GAME });
 
-    expect(reviews.length).toBeGreaterThanOrEqual(40);
-    expect(reviews.length).toBeLessThan(5000);
-    expect(new Set(reviews.map((review) => review.id)).size).toBe(reviews.length);
+    expect(reviews.length).toBeGreaterThan(0);
+    expect(reviews.length).toBeLessThan(REVIEWS_ALL_CEILING);
+    expectReviewsContract(reviews, 'drained reviewsAll');
   });
 });

--- a/e2e/list.e2e.test.ts
+++ b/e2e/list.e2e.test.ts
@@ -1,18 +1,10 @@
 import { expect, it } from 'vitest';
 import { type ListItem } from '../src/index.js';
+import { expectAppItemsContract } from './contracts.js';
 import { expectFieldCoverage, liveClient, liveDescribe } from './helpers.js';
 
-const assertValidItem = (item: ListItem): void => {
-  expect(item.appId.length).toBeGreaterThan(0);
-  expect(item.title.length).toBeGreaterThan(0);
-  expect(new URL(item.url).origin).toBe('https://play.google.com');
-  expect(typeof item.price).toBe('number');
-  expect(typeof item.free).toBe('boolean');
-  if (item.score !== undefined) {
-    expect(item.score).toBeGreaterThanOrEqual(0);
-    expect(item.score).toBeLessThanOrEqual(5);
-  }
-};
+const LIST_CEILING_PROBE = 500;
+const LIST_CEILING_FLOOR = 150;
 
 liveDescribe('list live contract', () => {
   it('returns exactly ten free games for the top free game collection', async () => {
@@ -23,8 +15,8 @@ liveDescribe('list live contract', () => {
     })) as ListItem[];
 
     expect(items).toHaveLength(10);
+    expectAppItemsContract(items, 'top free games');
     for (const item of items) {
-      assertValidItem(item);
       expect(item.free).toBe(true);
       expect(item.price).toBe(0);
     }
@@ -52,8 +44,8 @@ liveDescribe('list live contract', () => {
     })) as ListItem[];
 
     expect(items.length).toBeGreaterThan(0);
+    expectAppItemsContract(items, 'top paid applications');
     for (const item of items) {
-      assertValidItem(item);
       expect(item.price).toBeGreaterThan(0);
       expect(item.free).toBe(false);
     }
@@ -67,8 +59,8 @@ liveDescribe('list live contract', () => {
     })) as ListItem[];
 
     expect(items).toHaveLength(5);
+    expectAppItemsContract(items, 'top paid games');
     for (const item of items) {
-      assertValidItem(item);
       expect(item.free).toBe(false);
       expect(item.price).toBeGreaterThan(0);
     }
@@ -78,9 +70,7 @@ liveDescribe('list live contract', () => {
     const items = (await liveClient.list({ collection: 'GROSSING', num: 5 })) as ListItem[];
 
     expect(items).toHaveLength(5);
-    for (const item of items) {
-      assertValidItem(item);
-    }
+    expectAppItemsContract(items, 'grossing collection');
   });
 
   it('returns valid apps across social, productivity, and trivia game categories', async () => {
@@ -94,9 +84,7 @@ liveDescribe('list live contract', () => {
       })) as ListItem[];
 
       expect(items.length).toBeGreaterThan(0);
-      for (const item of items) {
-        assertValidItem(item);
-      }
+      expectAppItemsContract(items, `${category} top free`);
     }
   });
 
@@ -109,20 +97,18 @@ liveDescribe('list live contract', () => {
     })) as ListItem[];
 
     expect(items).toHaveLength(10);
-    for (const item of items) {
-      assertValidItem(item);
-    }
+    expectAppItemsContract(items, 'family age filtered');
   });
 
   it('caps at the google ceiling when num exceeds it', async () => {
     const items = (await liveClient.list({
       collection: 'TOP_FREE',
       category: 'APPLICATION',
-      num: 500,
+      num: LIST_CEILING_PROBE,
     })) as ListItem[];
 
-    expect(items.length).toBeGreaterThanOrEqual(150);
-    expect(items.length).toBeLessThanOrEqual(500);
-    expect(new Set(items.map((item) => item.appId)).size).toBe(items.length);
+    expect(items.length).toBeGreaterThanOrEqual(LIST_CEILING_FLOOR);
+    expect(items.length).toBeLessThanOrEqual(LIST_CEILING_PROBE);
+    expectAppItemsContract(items, 'list ceiling');
   });
 });

--- a/e2e/list.e2e.test.ts
+++ b/e2e/list.e2e.test.ts
@@ -4,7 +4,7 @@ import { expectAppItemsContract } from './contracts.js';
 import { expectFieldCoverage, liveClient, liveDescribe } from './helpers.js';
 
 const LIST_CEILING_PROBE = 500;
-const LIST_CEILING_FLOOR = 150;
+const LIST_MAX_ITEMS = 200;
 
 liveDescribe('list live contract', () => {
   it('returns exactly ten free games for the top free game collection', async () => {
@@ -107,8 +107,7 @@ liveDescribe('list live contract', () => {
       num: LIST_CEILING_PROBE,
     })) as ListItem[];
 
-    expect(items.length).toBeGreaterThanOrEqual(LIST_CEILING_FLOOR);
-    expect(items.length).toBeLessThanOrEqual(LIST_CEILING_PROBE);
+    expect(items).toHaveLength(LIST_MAX_ITEMS);
     expectAppItemsContract(items, 'list ceiling');
   });
 });

--- a/e2e/reviews.e2e.test.ts
+++ b/e2e/reviews.e2e.test.ts
@@ -1,34 +1,35 @@
 import { expect, it } from 'vitest';
 import { sort, type IntegrityEvent } from '../src/index.js';
+import { expectReviewsContract } from './contracts.js';
 import { expectFieldCoverage, liveClient, liveDescribe } from './helpers.js';
 
 const TRANSLATE = 'com.google.android.apps.translate';
+const GEO_GAME = 'com.adex77.WhereAmI';
+const WHATSAPP = 'com.whatsapp';
+const REVIEW_PAGE_FLOOR = 100;
+const ACCUMULATED_NUM = 320;
+const EXHAUSTION_PROBE = 5000;
+const LOCALIZED_OVERLAP_CEILING = 15;
 
 liveDescribe('reviews live contract', () => {
   it('returns a valid first page for the Where Am I geography game', async () => {
-    const result = await liveClient.reviews({ appId: 'com.adex77.WhereAmI', paginate: true });
+    const result = await liveClient.reviews({ appId: GEO_GAME, paginate: true });
 
     expect(result.data.length).toBeGreaterThan(0);
-    for (const review of result.data) {
-      expect(review.id.length).toBeGreaterThan(0);
-      expect(review.userName.length).toBeGreaterThan(0);
-      expect(review.score).toBeGreaterThanOrEqual(1);
-      expect(review.score).toBeLessThanOrEqual(5);
-      expect(Number.isNaN(Date.parse(review.date))).toBe(false);
-    }
+    expectReviewsContract(result.data, 'geography game reviews');
   });
 
   it('accumulates exactly the requested number of reviews with unique ids', async () => {
     const events: IntegrityEvent[] = [];
     const result = await liveClient.reviews({
       appId: TRANSLATE,
-      num: 320,
+      num: ACCUMULATED_NUM,
       onIntegrityEvent: (event) => events.push(event),
     });
 
-    expect(result.data).toHaveLength(320);
+    expect(result.data).toHaveLength(ACCUMULATED_NUM);
     expect(result.nextPaginationToken).toBeNull();
-    expect(new Set(result.data.map((review) => review.id)).size).toBe(320);
+    expectReviewsContract(result.data, 'accumulated reviews');
     expect(events).toEqual([]);
   });
 
@@ -64,10 +65,8 @@ liveDescribe('reviews live contract', () => {
 
     expect(byRating.data.length).toBeGreaterThan(0);
     expect(byHelpfulness.data.length).toBeGreaterThan(0);
-    for (const review of [...byRating.data, ...byHelpfulness.data]) {
-      expect(review.score).toBeGreaterThanOrEqual(1);
-      expect(review.score).toBeLessThanOrEqual(5);
-    }
+    expectReviewsContract(byRating.data, 'rating sorted reviews');
+    expectReviewsContract(byHelpfulness.data, 'helpfulness sorted reviews');
 
     expectFieldCoverage('reviews', byHelpfulness.data, {
       text: 0.8,
@@ -76,9 +75,10 @@ liveDescribe('reviews live contract', () => {
   });
 
   it('returns the newest sort in non increasing date order', async () => {
-    const result = await liveClient.reviews({ appId: 'com.whatsapp', paginate: true });
+    const result = await liveClient.reviews({ appId: WHATSAPP, paginate: true });
 
-    expect(result.data.length).toBeGreaterThan(100);
+    expect(result.data.length).toBeGreaterThan(REVIEW_PAGE_FLOOR);
+    expectReviewsContract(result.data, 'newest sorted reviews');
     const timestamps = result.data.map((review) => Date.parse(review.date));
     for (const [index, timestamp] of timestamps.entries()) {
       if (index > 0) {
@@ -88,26 +88,21 @@ liveDescribe('reviews live contract', () => {
   });
 
   it('serves a disjoint localized first page for a polish storefront', async () => {
-    const defaultPage = await liveClient.reviews({ appId: 'com.whatsapp', paginate: true });
+    const defaultPage = await liveClient.reviews({ appId: WHATSAPP, paginate: true });
     const polishPage = await liveClient.reviews({
-      appId: 'com.whatsapp',
+      appId: WHATSAPP,
       paginate: true,
       lang: 'pl',
       country: 'pl',
     });
 
-    expect(polishPage.data.length).toBeGreaterThan(100);
+    expect(polishPage.data.length).toBeGreaterThan(REVIEW_PAGE_FLOOR);
     expect(polishPage.nextPaginationToken).not.toBeNull();
-    for (const review of polishPage.data) {
-      expect(review.id.length).toBeGreaterThan(0);
-      expect(review.score).toBeGreaterThanOrEqual(1);
-      expect(review.score).toBeLessThanOrEqual(5);
-      expect(Number.isNaN(Date.parse(review.date))).toBe(false);
-    }
+    expectReviewsContract(polishPage.data, 'polish storefront reviews');
 
     const defaultIds = new Set(defaultPage.data.map((review) => review.id));
     const overlap = polishPage.data.filter((review) => defaultIds.has(review.id)).length;
-    expect(overlap).toBeLessThan(15);
+    expect(overlap).toBeLessThan(LOCALIZED_OVERLAP_CEILING);
   });
 
   it('returns an empty page instead of throwing for a missing app', async () => {
@@ -121,11 +116,11 @@ liveDescribe('reviews live contract', () => {
   });
 
   it('returns every available review and stops when num exceeds the total', async () => {
-    const result = await liveClient.reviews({ appId: 'com.adex77.WhereAmI', num: 5000 });
+    const result = await liveClient.reviews({ appId: GEO_GAME, num: EXHAUSTION_PROBE });
 
-    expect(result.data.length).toBeGreaterThanOrEqual(40);
-    expect(result.data.length).toBeLessThan(5000);
+    expect(result.data.length).toBeGreaterThan(0);
+    expect(result.data.length).toBeLessThan(EXHAUSTION_PROBE);
     expect(result.nextPaginationToken).toBeNull();
-    expect(new Set(result.data.map((review) => review.id)).size).toBe(result.data.length);
+    expectReviewsContract(result.data, 'exhausted reviews');
   });
 });

--- a/e2e/search.e2e.test.ts
+++ b/e2e/search.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   type IntegrityEvent,
   type SearchResult,
 } from '../src/index.js';
+import { expectAppItemsContract } from './contracts.js';
 import { expectFieldCoverage, liveClient, liveDescribe } from './helpers.js';
 
 const FIRST_PAGE_CEILING = 40;
@@ -40,19 +41,7 @@ liveDescribe('search live contract', () => {
     })) as SearchResult[];
 
     expect(results.length).toBeGreaterThan(10);
-    expect(new Set(results.map((item) => item.appId)).size).toBe(results.length);
-
-    for (const item of results) {
-      expect(item.appId.length).toBeGreaterThan(0);
-      expect(item.title.length).toBeGreaterThan(0);
-      expect(new URL(item.url).origin).toBe('https://play.google.com');
-      expect(typeof item.price).toBe('number');
-      expect(typeof item.free).toBe('boolean');
-      if (item.score !== undefined) {
-        expect(item.score).toBeGreaterThanOrEqual(0);
-        expect(item.score).toBeLessThanOrEqual(5);
-      }
-    }
+    expectAppItemsContract(results, 'broad term search');
     expect(events).toEqual([]);
   });
 
@@ -74,6 +63,7 @@ liveDescribe('search live contract', () => {
     })) as SearchResult[];
 
     expect(results.length).toBeGreaterThan(0);
+    expectAppItemsContract(results, 'free filtered search');
     for (const item of results) {
       expect(item.free).toBe(true);
       expect(item.price).toBe(0);
@@ -94,6 +84,7 @@ liveDescribe('search live contract', () => {
     })) as SearchResult[];
 
     expect(results.length).toBeGreaterThan(0);
+    expectAppItemsContract(results, 'paid filtered search');
     for (const item of results) {
       expect(item.free).toBe(false);
       expect(item.price).toBeGreaterThan(0);
@@ -104,10 +95,7 @@ liveDescribe('search live contract', () => {
     const results = (await liveClient.search({ term: 'ポケモン', num: 10 })) as SearchResult[];
 
     expect(results.length).toBeGreaterThanOrEqual(5);
-    for (const item of results) {
-      expect(item.appId.length).toBeGreaterThan(0);
-      expect(item.title.length).toBeGreaterThan(0);
-    }
+    expectAppItemsContract(results, 'non latin search');
   });
 
   it('returns localized results for a german term with diacritics', async () => {
@@ -120,10 +108,7 @@ liveDescribe('search live contract', () => {
 
     expect(results.length).toBeGreaterThanOrEqual(10);
     expect(results.some((item) => item.title.toLowerCase().includes('übersetzer'))).toBe(true);
-    for (const item of results) {
-      expect(item.appId.length).toBeGreaterThan(0);
-      expect(item.title.length).toBeGreaterThan(0);
-    }
+    expectAppItemsContract(results, 'german search');
   });
 
   it('serves the full first page without truncation when num exceeds the google cap', async () => {
@@ -150,7 +135,7 @@ liveDescribe('search live contract', () => {
     const resultIds = results.map((item) => item.appId);
 
     expect(resultIds).toEqual(firstPageIds);
-    expect(new Set(resultIds).size).toBe(resultIds.length);
+    expectAppItemsContract(results, 'first page search');
     expectFieldCoverage('search', results, {
       score: 0.8,
       scoreText: 0.8,

--- a/e2e/similar.e2e.test.ts
+++ b/e2e/similar.e2e.test.ts
@@ -1,22 +1,27 @@
 import { expect, it } from 'vitest';
+import { SIMILAR_MAX_APPS } from '../src/features/similar/specs.js';
 import { NotFoundError, type DegradationEvent, type SimilarApp } from '../src/index.js';
+import { expectAppItemsContract } from './contracts.js';
 import { expectFieldCoverage, liveClient, liveDescribe } from './helpers.js';
 
+const SIMILAR_CLUSTER_PAGE_SIZE = 50;
+
 liveDescribe('similar live contract', () => {
-  it('returns similar games for the Where Am I geography game', async () => {
+  it('returns a well formed cluster for the Where Am I geography game', async ({ annotate }) => {
     const sourceAppId = 'com.adex77.WhereAmI';
     const items = (await liveClient.similar({ appId: sourceAppId })) as SimilarApp[];
 
-    expect(items.length).toBeGreaterThan(0);
+    expectAppItemsContract(items, 'geography game similar cluster');
     expect(items.some((item) => item.appId === sourceAppId)).toBe(false);
-    for (const item of items) {
-      expect(item.appId.length).toBeGreaterThan(0);
-      expect(item.title.length).toBeGreaterThan(0);
-      expect(new URL(item.url).origin).toBe('https://play.google.com');
-    }
+    expect(items.length).toBeLessThanOrEqual(SIMILAR_MAX_APPS);
+
+    await annotate(
+      `${sourceAppId} is recommended alongside ${items.length.toString()} apps`,
+      'notice',
+    );
   });
 
-  it('returns related apps that exclude the source app', async () => {
+  it('follows the cluster continuation for a flagship source app', async () => {
     const sourceAppId = 'com.google.android.apps.translate';
     const events: DegradationEvent[] = [];
     const items = (await liveClient.similar({
@@ -24,16 +29,10 @@ liveDescribe('similar live contract', () => {
       onDegradation: (event) => events.push(event),
     })) as SimilarApp[];
 
-    expect(items.length).toBeGreaterThanOrEqual(60);
+    expect(items.length).toBeGreaterThan(SIMILAR_CLUSTER_PAGE_SIZE);
+    expect(items.length).toBeLessThanOrEqual(SIMILAR_MAX_APPS);
     expect(items.some((item) => item.appId === sourceAppId)).toBe(false);
-    expect(new Set(items.map((item) => item.appId)).size).toBe(items.length);
-
-    for (const item of items) {
-      expect(item.appId.length).toBeGreaterThan(0);
-      expect(item.title.length).toBeGreaterThan(0);
-      expect(new URL(item.url).origin).toBe('https://play.google.com');
-      expect(typeof item.free).toBe('boolean');
-    }
+    expectAppItemsContract(items, 'flagship similar cluster');
 
     expectFieldCoverage('similar', items, {
       score: 0.8,


### PR DESCRIPTION
## Summary

The scheduled live contract run failed because `org.asccp.app2019` picked up three similar-app recommendations, and the edge case suite asserted `similar()` returns `[]` for it — pinning Google's recommendation engine, not the scraper's behavior. That empty-cluster parse path was already covered offline against fixtures in `src/features/similar/similar.test.ts`, so the live assertion added drift risk without adding coverage.

Auditing the rest of `e2e/` turned up the same class of assertion throughout: an app currently having zero reviews, a category currently being empty, a title currently being in Play Pass, a game still being in preregistration, exact similar/developer counts. Each of these moves independently of the scraper and will eventually fail the scheduled run again for the same non-reason.

## What changed

- Added `e2e/contracts.ts`: shared invariant helpers asserting cross-field agreement (`free`/`price`/`currency`, `score`/`scoreText`, `installs`/`minInstalls`, histogram vs. rating count, `offersIAP`/`IAPRange`, preregistration release state) — these break the instant a scrape path drifts and never break when the catalogue moves. Two tolerances are measured against live data, not guessed: histogram tracks ratings to within `max(10, 1% of ratings)`, and `scoreText` rounds `score` to one decimal within 0.051.
- Rewrote the volatile assertions across `edgeCases`, `app`, `similar`, `developer`, `list`, `search`, `reviews`, `iterators`, and `datasafety` to branch on what the page actually reports (annotated via vitest's `annotate`) instead of assuming a state, or to anchor counts to measured page sizes / the requested `num` instead of catalogue size.
- Where live coverage of a specific commercial state is still wanted (Play Pass, in-app purchases, rich media fields), moved to anchor pools that fail only when every anchor in the pool has drifted, with a failure message naming the re-anchoring task.
- Documented the six legitimate assertion kinds, the catalogue state that must never be pinned, the shared helpers and their measured tolerances, and the maintained anchor pools (including where to refresh the preregistration candidate list) in `docs/RUNBOOK.md`, cross-referenced from `CONTRIBUTING.md`.

Closes #105

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:coverage` (99.5% statements, 624 tests)
- [x] `pnpm build`
- [x] `pnpm test:e2e` — 141/141 passing against live Google Play, run twice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded live end-to-end coverage for listings, search, reviews, pagination, similar apps, localization, safety, permissions, purchases, and preregistration.
  * Added consistent validation for response fields, value ranges, URLs, uniqueness, and cross-field relationships.
  * Improved resilience by validating stable contracts across sparse, mixed, localized, and exhausted result sets.
  * Added coverage for commercial details, data-safety requirements, rating consistency, and localized storefronts.

* **Documentation**
  * Added guidance for conditional assertions, pagination limits, contract validation, and maintaining registered test anchors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->