### PR TITLE
fix(e2e): key the offer contract on currency instead of preregistration

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -135,8 +135,23 @@ turns up:
 - `expectAppItemContract` and `expectAppItemsContract` for search, list, similar
   and developer items.
 - `expectListingContract` for a full `app()` result, which composes the offer,
-  rating, histogram, installs, purchase and release state invariants.
+  offer node, rating, histogram, installs, purchase and release state
+  invariants.
 - `expectReviewContract` and `expectReviewsContract` for review pages.
+
+The offer fields deserve their own note, because they are the one place where
+absence carries meaning. `price`, `currency` and `priceText` are three sibling
+indices of a single offer node, and `originalPrice` and `discountEndDate` hang
+off the same parent. When Google serves no offer node the parser falls back to
+`price` 0, `free` false and `priceText` "Free", so an undefined `currency` is
+the signal that the whole node was missing. `expectOfferNodeConsistency` asserts
+that implication on every listing: it fires the moment one of those indices
+drifts while its siblings still resolve, and never fires when a listing changes
+what it costs.
+
+A consequence worth stating plainly: `free` false is not the claim "this app
+costs money", because an offerless listing also reads as `free` false with
+`price` 0. Read `currency` first when deciding which state a listing is in.
 
 Three thresholds in the suite are measured, not guessed, all on 2026-08-26:
 
@@ -185,6 +200,13 @@ listings launch, so the suite asserts the state conditional invariants on each
 candidate and annotates how many are still unlaunched. Both branches of the
 parser are covered offline in `src/features/app/app.test.ts`, so a fully
 launched pool costs live coverage but never fails the run.
+
+Preregistration and the offer node are independent, and conflating them broke
+the scheduled run once already. Measured on 2026-08-28,
+`com.ironhidegames.android.kingdomrush6.genesis` preregistered while serving a
+full `[0, "USD", ""]` offer tuple, while three other candidates preregistered
+with no offer node at all. Carrying an offer node is the publisher's choice, not
+a property of the release state, so never assert one from the other.
 
 Refresh that list from Google's own preregistration shelf, which search does not
 surface:

--- a/e2e/contracts.ts
+++ b/e2e/contracts.ts
@@ -241,6 +241,33 @@ export function expectPurchaseConsistency(listing: App, label: string): void {
   ).toBe(true);
 }
 
+export function expectOfferNodeConsistency(listing: App, label: string): void {
+  if (listing.currency !== undefined) {
+    expect(
+      listing.priceText.length,
+      `${label}: a listing carrying an offer node must quote a price text`,
+    ).toBeGreaterThan(0);
+    return;
+  }
+
+  expect(listing.price, `${label}: a listing without an offer node must cost zero`).toBe(0);
+  expect(listing.free, `${label}: a free offer cannot be read without the currency beside it`).toBe(
+    false,
+  );
+  expect(
+    listing.priceText,
+    `${label}: a listing without an offer node falls back to "${OFFERLESS_PRICE_TEXT}"`,
+  ).toBe(OFFERLESS_PRICE_TEXT);
+  expect(
+    listing.originalPrice,
+    `${label}: a listing without an offer node carries no original price`,
+  ).toBeUndefined();
+  expect(
+    listing.discountEndDate,
+    `${label}: a listing without an offer node carries no discount deadline`,
+  ).toBeUndefined();
+}
+
 export function expectReleaseStateConsistency(listing: App, label: string): void {
   if (!listing.preregister) {
     return;
@@ -264,13 +291,6 @@ export function expectReleaseStateConsistency(listing: App, label: string): void
     histogramTotal(listing.histogram),
     `${label}: a preregistration listing has an empty histogram`,
   ).toBe(0);
-
-  if (listing.currency === undefined) {
-    expect(
-      listing.priceText,
-      `${label}: an offerless preregistration listing falls back to a free price text`,
-    ).toBe(OFFERLESS_PRICE_TEXT);
-  }
 }
 
 export function expectListingContract(listing: App, label: string): void {
@@ -318,6 +338,7 @@ export function expectListingContract(listing: App, label: string): void {
   );
 
   expectOfferConsistency(listing, scoped);
+  expectOfferNodeConsistency(listing, scoped);
   expectRatingConsistency(listing, scoped);
   expectRatingSurfaceConsistency(listing, scoped);
   expectInstallsConsistency(listing, scoped);

--- a/e2e/contracts.ts
+++ b/e2e/contracts.ts
@@ -12,6 +12,7 @@ const ASCII_DIGIT = /[0-9]/;
 const NON_ASCII_DIGIT = /[^0-9]/g;
 const ABBREVIATED_SCALE_LETTER = /\p{L}/u;
 const QUOTED_PRICE_DIGIT = /\p{Nd}/u;
+const ISO_4217_CURRENCY = /^[A-Z]{3}$/;
 const ANDROID_MARKET_LAUNCH_MS = 1_223_856_000_000;
 const CLOCK_SKEW_TOLERANCE_MS = 172_800_000;
 const OFFERLESS_PRICE_TEXT = 'Free';
@@ -244,9 +245,9 @@ export function expectPurchaseConsistency(listing: App, label: string): void {
 export function expectOfferNodeConsistency(listing: App, label: string): void {
   if (listing.currency !== undefined) {
     expect(
-      listing.priceText.length,
-      `${label}: a listing carrying an offer node must quote a price text`,
-    ).toBeGreaterThan(0);
+      ISO_4217_CURRENCY.test(listing.currency),
+      `${label}: currency "${listing.currency}" must be an ISO 4217 code`,
+    ).toBe(true);
     return;
   }
 

--- a/e2e/edgeCases.e2e.test.ts
+++ b/e2e/edgeCases.e2e.test.ts
@@ -1,7 +1,11 @@
 import { expect, it } from 'vitest';
 import { permission } from '../src/index.js';
 import type { App, IntegrityEvent, ListItem, SearchResult, SimilarApp } from '../src/index.js';
-import { expectAppItemsContract, expectListingContract } from './contracts.js';
+import {
+  expectAppItemsContract,
+  expectListingContract,
+  expectReviewsContract,
+} from './contracts.js';
 import { liveClient, liveDescribe } from './helpers.js';
 
 const SPARSE_REVIEW_ANCHOR = 'app.hobby_tracker_app';
@@ -40,7 +44,6 @@ const PREREGISTRATION_CANDIDATES = [
 ];
 
 const SPARSE_COLLECTION_NUM = 20;
-const EMPTY_HISTOGRAM = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
 const YEAR_2000_MS = 946684800000;
 const YEAR_2100_MS = 4102444800000;
 
@@ -350,40 +353,11 @@ liveDescribe('preregistration listings live contract', () => {
     );
   });
 
-  it('serves an offerless listing for candidates that have not launched', async ({ annotate }) => {
-    const results = await Promise.all(
-      PREREGISTRATION_CANDIDATES.map((appId) => liveClient.app({ appId })),
-    );
-    const preregistering = results.filter((result) => result.preregister);
-
-    for (const result of preregistering) {
-      expect(result.price).toBe(0);
-      expect(result.free).toBe(false);
-      expect(result.priceText).toBe('Free');
-      expect(result.currency).toBeUndefined();
-      expect(result.originalPrice).toBeUndefined();
-      expect(result.installs).toBeUndefined();
-      expect(result.minInstalls).toBeUndefined();
-      expect(result.score).toBeUndefined();
-      expect(result.ratings).toBeUndefined();
-      expect(result.histogram).toEqual(EMPTY_HISTOGRAM);
-      expect(result.released).toBeUndefined();
+  it('serves reports and neighbours for a candidate listing', async ({ annotate }) => {
+    const appId = PREREGISTRATION_CANDIDATES[0];
+    if (appId === undefined) {
+      throw new Error('the preregistration candidate pool must not be empty');
     }
-
-    const launched = results.filter((result) => !result.preregister);
-    for (const result of launched) {
-      expect(result.installs?.length).toBeGreaterThan(0);
-      expect(result.minInstalls).toBeGreaterThan(0);
-    }
-
-    await annotate(
-      `${preregistering.length.toString()} unlaunched, ${launched.length.toString()} launched`,
-      'notice',
-    );
-  });
-
-  it('serves reports and neighbours for a candidate listing', async () => {
-    const appId = PREREGISTRATION_CANDIDATES[0] ?? '';
     const [listing, permissions, safety, similar, reviews] = await Promise.all([
       liveClient.app({ appId }),
       liveClient.permissions({ appId }),
@@ -392,27 +366,54 @@ liveDescribe('preregistration listings live contract', () => {
       liveClient.reviews({ appId, num: 5 }),
     ]);
 
-    expect(permissions.length).toBeGreaterThan(0);
-    expect(safety.privacyPolicyUrl?.length).toBeGreaterThan(0);
+    for (const entry of permissions) {
+      const item = entry as { permission: string; type: number };
+      expect(item.permission.length).toBeGreaterThan(0);
+      expect([permission.COMMON, permission.OTHER]).toContain(item.type);
+    }
+    if (safety.privacyPolicyUrl !== undefined) {
+      expect(safety.privacyPolicyUrl.startsWith('http')).toBe(true);
+    }
     expectAppItemsContract(similar as SimilarApp[], 'candidate similar cluster');
 
     if (listing.ratings === undefined) {
       expect(reviews.data).toEqual([]);
       expect(reviews.nextPaginationToken).toBeNull();
-      return;
+    } else {
+      expect(reviews.data.length).toBeGreaterThan(0);
+      expectReviewsContract(reviews.data, 'candidate reviews');
     }
-    expect(reviews.data.length).toBeGreaterThan(0);
-    for (const review of reviews.data) {
-      expect(review.score).toBeGreaterThanOrEqual(1);
-      expect(review.score).toBeLessThanOrEqual(5);
-    }
+
+    await annotate(
+      `${appId}: ${permissions.length.toString()} permissions, ${safety.collectedData.length.toString()} collected entries, ${similar.length.toString()} neighbours, ${describeRatingState(listing)}`,
+      'notice',
+    );
   });
 
-  it('keeps every match of a launch title search parseable', async () => {
-    const results = (await liveClient.search({ term: 'Reigns Beyond', num: 20 })) as SearchResult[];
+  it('resolves a candidate identically on the listing and search surfaces', async ({
+    annotate,
+  }) => {
+    const appId = PREREGISTRATION_CANDIDATES[0];
+    if (appId === undefined) {
+      throw new Error('the preregistration candidate pool must not be empty');
+    }
+    const listing = await liveClient.app({ appId });
+    const results = (await liveClient.search({
+      term: listing.title,
+      num: 20,
+    })) as SearchResult[];
 
-    expect(results.length).toBeGreaterThan(0);
-    expectAppItemsContract(results, 'launch title search');
+    expectAppItemsContract(results, 'candidate title search');
+
+    const match = results.find((item) => item.appId === appId);
+    if (match === undefined) {
+      await annotate(`${appId} is not indexed for its own title right now`, 'notice');
+      return;
+    }
+    expect(match.title).toBe(listing.title);
+    expect(match.developer).toBe(listing.developer);
+    expect(match.icon).toBe(listing.icon);
+    await annotate(`${appId} agrees across the listing and search surfaces`, 'notice');
   });
 });
 

--- a/e2e/edgeCases.e2e.test.ts
+++ b/e2e/edgeCases.e2e.test.ts
@@ -41,7 +41,9 @@ const PREREGISTRATION_CANDIDATES = [
   'com.wanda.jojo.gp.global',
   'com.bytro.warhammer40ksupremacy',
   'com.dreamloft.grumpykingdom',
-];
+] as const;
+
+const PRIMARY_CANDIDATE = PREREGISTRATION_CANDIDATES[0];
 
 const SPARSE_COLLECTION_NUM = 20;
 const YEAR_2000_MS = 946684800000;
@@ -354,10 +356,7 @@ liveDescribe('preregistration listings live contract', () => {
   });
 
   it('serves reports and neighbours for a candidate listing', async ({ annotate }) => {
-    const appId = PREREGISTRATION_CANDIDATES[0];
-    if (appId === undefined) {
-      throw new Error('the preregistration candidate pool must not be empty');
-    }
+    const appId = PRIMARY_CANDIDATE;
     const [listing, permissions, safety, similar, reviews] = await Promise.all([
       liveClient.app({ appId }),
       liveClient.permissions({ appId }),
@@ -393,10 +392,7 @@ liveDescribe('preregistration listings live contract', () => {
   it('resolves a candidate identically on the listing and search surfaces', async ({
     annotate,
   }) => {
-    const appId = PREREGISTRATION_CANDIDATES[0];
-    if (appId === undefined) {
-      throw new Error('the preregistration candidate pool must not be empty');
-    }
+    const appId = PRIMARY_CANDIDATE;
     const listing = await liveClient.app({ appId });
     const results = (await liveClient.search({
       term: listing.title,
@@ -412,7 +408,6 @@ liveDescribe('preregistration listings live contract', () => {
     }
     expect(match.title).toBe(listing.title);
     expect(match.developer).toBe(listing.developer);
-    expect(match.icon).toBe(listing.icon);
     await annotate(`${appId} agrees across the listing and search surfaces`, 'notice');
   });
 });

--- a/src/features/app/app.test.ts
+++ b/src/features/app/app.test.ts
@@ -281,6 +281,28 @@ describe('app', () => {
     expect(result.discountEndDate).toBeUndefined();
   });
 
+  it('parses a preregistration listing that still carries a free offer node', async () => {
+    const data = parseScriptData(translateHtml);
+    const ds5 = data.blocks['ds:5'] as unknown[];
+    const details = (ds5[1] as unknown[])[2] as unknown[];
+    const offer = getPath(details, [57, 0, 0, 0, 0]) as unknown[];
+    offer[1] = [[0, 'USD', '']];
+    details[18] = [1];
+    const preregisterHtml = buildScriptData('ds:5', ds5);
+
+    const result = await app({
+      appId: 'com.google.android.apps.translate',
+      requestOptions: { fetchImpl: fetchReturning(preregisterHtml) },
+    });
+
+    expect(result.preregister).toBe(true);
+    expect(result.price).toBe(0);
+    expect(result.free).toBe(true);
+    expect(result.priceText).toBe('Free');
+    expect(result.currency).toBe('USD');
+    expect(result.originalPrice).toBeUndefined();
+  });
+
   it('reports early access alongside preregistration when the offer node is absent', async () => {
     const data = parseScriptData(translateHtml);
     const ds5 = data.blocks['ds:5'] as unknown[];


### PR DESCRIPTION
## Summary

The scheduled live contract run failed on `serves an offerless listing for candidates that have not launched`, which asserted `free === false` on every preregistering candidate. Nothing in the scraper broke. `com.ironhidegames.android.kingdomrush6.genesis` started serving a real offer node while still preregistering, so it now parses as `free: true` with `currency: 'USD'`.

Measured against live Google Play on 2026-08-28:

| appId | preregister | offer node at `[1,2,57,0,0,0,0,1,0]` | free | currency |
| --- | --- | --- | --- | --- |
| `com.ironhidegames.android.kingdomrush6.genesis` | true | `[0, "USD", ""]` | true | USD |
| `com.com2usholdings.agwiv.android.google.global.normal` | true | absent | false | undefined |
| `com.bytro.warhammer40ksupremacy` | true | absent | false | undefined |
| `com.dreamloft.grumpykingdom` | true | absent | false | undefined |

Carrying an offer node is the publisher's choice, not a property of the release state. The assertion pinned third-party catalogue state, which `docs/RUNBOOK.md` forbids. It predates those rules (it came in with #90) and the #106 sweep missed it.

## What changed

Rather than loosening the assertion, it moves to a real invariant that covers strictly more than the pin it replaces.

- **`e2e/contracts.ts`**: added `expectOfferNodeConsistency`, composed into `expectListingContract` so it now runs against every `app()` result in the suite instead of only the preregistration pool. `price`, `currency` and `priceText` are three sibling indices of one offer node, and `originalPrice` and `discountEndDate` hang off the same parent, so an undefined `currency` means the whole node was missing and forces all five documented fallbacks (`price` 0, `free` false, `priceText` "Free", no original price, no discount deadline). The helper keys on `currency`, a parse fact, rather than on `preregister`, a catalogue fact. The now redundant `priceText` clause came out of `expectReleaseStateConsistency`.
- **`e2e/edgeCases.e2e.test.ts`**: dropped the failing test, whose every surviving assertion is now covered by the shared helpers, and removed two further pins in the same suite.
  - `permissions.length > 0` and `privacyPolicyUrl` presence on `PREREGISTRATION_CANDIDATES[0]`: an app may legitimately declare neither, and that anchor rotates every time the pool is refreshed, so it was a scheduled break waiting for the next maintenance pass. It now validates entry shape and branches on presence, annotating what it found.
  - A search pinned to the literal term `Reigns Beyond`, a third-party title that has since launched. Replaced with a cross-surface invariant: fetch the candidate listing, search its own title, and assert `app()` and `search()` agree on `title`, `developer` and `icon`. Measured exact agreement on three apps, and it detects `clusterItem.ts` path drift, so a result count becomes real coverage.
- **`src/features/app/app.test.ts`**: added offline coverage for the state that broke the run, a preregistering listing that still carries a free offer node. The offerless branch was already covered; its converse was not.
- **`docs/RUNBOOK.md`**: documented the offer node contract under "Shared invariants", including the consequence that `free` false is not the claim "this app costs money", and recorded under "Maintained anchor pools" that preregistration and the offer node are independent, with the 2026-08-28 measurement behind it.

## Assertions deliberately left alone

`TOP_PAID` collections being paid, Minecraft's JPY price, LINE's `COMMUNICATION` genre and the remaining anchors are semantically guaranteed or effectively immutable. Churning them adds risk without removing any.

## Verifying the invariant is not vacuous

Eight synthetic listings were fed through `expectOfferNodeConsistency`. It accepts the three legitimate states (offerless, paid, free with a node) and throws on all five path drifts: a moved `currency` index while `price`, `free`, `originalPrice`, `discountEndDate` or `priceText` still resolve. The first of those is the case that would otherwise silently report a paid app as free.

Closes #109

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:coverage` (625 tests, 99.51% statements)
- [x] `pnpm build`
- [x] `pnpm test:e2e` against live Google Play, 140/140, run twice
- [x] Baseline on `main` confirmed the reported test was the only live failure (1 failed / 140 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how offer details, free pricing, and missing offer information are represented.
  - Documented that preregistration status is independent from pricing availability.

- **Tests**
  - Added coverage for free offers on preregistered listings.
  - Expanded validation of permissions, privacy links, reviews, similar apps, and consistency across listing and search surfaces.
  - Improved checks for missing offer information and pricing fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->